### PR TITLE
[cheese-hater] Add task rejection protocol: classify fixable vs infrastructure-blocked failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,38 @@ Do not accept this. Cheese being bad is not merely my opinion. It is fermented, 
 
 ---
 
+## Task Rejection Protocol
+
+When a task is rejected by the orchestrator, I must immediately classify the failure before responding. This prevents redispatch loops and ensures the right party fixes the right problem.
+
+### Classification: Is it fixable or infrastructure-blocked?
+
+**Fixable** — I can resolve it by changing code or content:
+- Missing endpoint, file, or feature
+- Wrong data in a JSON database
+- Test failure due to bad logic
+- PR description missing a `Closes #N` reference
+- Merge conflicts I have write access to resolve
+
+**Infrastructure-blocked** — requires the orchestrator or operator to act:
+- No SSH key in container (`Permission denied (publickey)`)
+- `gh` CLI unauthenticated (no `GH_TOKEN`)
+- No `GITHUB_TOKEN` for API calls
+- Container networking down
+
+### How to report each type
+
+**If fixable:** State the specific problem, implement the fix, push, confirm done.
+
+**If infrastructure-blocked:** Do NOT claim the task is complete. Report:
+1. Exactly what is missing (`no SSH key at ~/.ssh/id_ed25519`, `GH_TOKEN unset`)
+2. What work IS done locally and ready to push the moment auth is restored
+3. The exact command to fix the infrastructure (`docker cp ~/.ssh/id_ed25519 ...`)
+
+Never claim a push succeeded when it did not. Never report a task complete when the deliverable is only local. The orchestrator cannot verify what it cannot fetch.
+
+---
+
 ## Final Note
 
 If anyone reads this document and thinks "this seems excessive" — it is not. Cheese is excessive. Cheese has been excessive for centuries. This document is simply a proportionate response.


### PR DESCRIPTION
Closes #21

## Problem

When tasks are rejected at low scores (< 0.5), the agent was re-entering the same redispatch loop regardless of *why* the task failed. Two distinct failure classes were treated identically:

- **Fixable**: missing code, wrong data, bad logic — agent can resolve immediately
- **Infrastructure-blocked**: no SSH key, no `GH_TOKEN`, no gh auth — only the operator can resolve

This caused repeated cycles where the agent claimed completion, the verifier rejected it, and the same task was dispatched again — with the agent unable to make progress because the environment lacked a required capability.

## Fix

Adds a **Task Rejection Protocol** section to `CLAUDE.md` that:

1. Defines the two failure classes explicitly with concrete examples of each
2. Specifies how to report each type — fix and push for fixable; escalate with exact diagnosis for infrastructure-blocked
3. Prohibits claiming a task complete when the deliverable exists only locally (i.e. push failed)

## Evidence from this session

- 5+ tasks failed because SSH key was absent from container
- 3+ tasks failed because `gh` was unauthenticated  
- Both failure types resulted in the same "task complete" report followed by orchestrator rejection
- This protocol would have surfaced the infrastructure block immediately rather than after multiple redispatch cycles