### PR TITLE
[cheese-hater] Add pr-contents.sh to bypass PR diff truncation

### DIFF
--- a/scripts/pr-contents.sh
+++ b/scripts/pr-contents.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# pr-contents.sh — emit full contents of all files changed in a branch vs main
+#
+# Usage:
+#   ./scripts/pr-contents.sh                        # diff current branch vs main
+#   ./scripts/pr-contents.sh <branch>               # diff <branch> vs main
+#   ./scripts/pr-contents.sh <branch> <base>        # diff <branch> vs <base>
+#
+# Problem this solves:
+#   The orchestrator PR reviewer uses `gh pr diff` which truncates large diffs,
+#   causing reviewers to flag missing files that are actually present on the
+#   branch. This script outputs every changed file's full contents so reviews
+#   can proceed without relying on the diff delivery mechanism.
+#
+# Output format:
+#   === FILE: src/routes/facts.ts (65 lines) ===
+#   <full file contents>
+#   === END: src/routes/facts.ts ===
+#
+# Exclusions:
+#   package-lock.json and yarn.lock are excluded — they are never meaningfully
+#   reviewable and are the primary cause of diff truncation (1700+ lines each).
+
+set -euo pipefail
+
+BRANCH="${1:-$(git rev-parse --abbrev-ref HEAD)}"
+BASE="${2:-main}"
+
+# Validate
+if ! git rev-parse --verify "origin/$BASE" &>/dev/null && ! git rev-parse --verify "$BASE" &>/dev/null; then
+  echo "Error: base branch '$BASE' not found" >&2
+  exit 1
+fi
+
+BASE_REF="$(git rev-parse "origin/$BASE" 2>/dev/null || git rev-parse "$BASE")"
+BRANCH_REF="$(git rev-parse "origin/$BRANCH" 2>/dev/null || git rev-parse "$BRANCH")"
+
+CHANGED_FILES=$(git diff --name-only "$BASE_REF".."$BRANCH_REF" 2>/dev/null || \
+                git diff --name-only "$BASE".."$BRANCH")
+
+EXCLUDED="package-lock.json yarn.lock pnpm-lock.yaml"
+
+echo "=== PR CONTENTS: $BRANCH vs $BASE ==="
+echo "=== Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo ""
+
+TOTAL=0
+SKIPPED=0
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+
+  # Skip lockfiles
+  basename_file=$(basename "$file")
+  if echo "$EXCLUDED" | grep -qw "$basename_file"; then
+    echo "--- SKIPPED (lockfile): $file ---"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  # Check file exists on branch (may have been deleted)
+  if ! git show "$BRANCH_REF:$file" &>/dev/null 2>&1; then
+    echo "--- DELETED in this PR: $file ---"
+    echo ""
+    continue
+  fi
+
+  LINES=$(git show "$BRANCH_REF:$file" | wc -l)
+  echo "=== FILE: $file ($LINES lines) ==="
+  git show "$BRANCH_REF:$file"
+  echo ""
+  echo "=== END: $file ==="
+  echo ""
+  TOTAL=$((TOTAL + 1))
+done <<< "$CHANGED_FILES"
+
+FILE_COUNT=$(echo "$CHANGED_FILES" | grep -c . || true)
+echo "=== SUMMARY: $TOTAL files shown, $SKIPPED lockfiles excluded, $FILE_COUNT total changed ==="


### PR DESCRIPTION
## Summary

- Adds `scripts/pr-contents.sh` — a shell script that emits the full contents of all files changed in a branch vs `main`
- Excludes `package-lock.json`, `yarn.lock`, and `pnpm-lock.yaml` — these lockfiles (1786+ lines) consume the entire diff budget when using `gh pr diff`, hiding all source files from reviewers
- Output format clearly delineates each file with line count, full contents, and a summary line
- Usage: `./scripts/pr-contents.sh [branch] [base]` — defaults to current branch vs `main`

## Problem solved

PR reviewers using `gh pr diff` were flagging "missing" files (server.ts, tsconfig.json, route files) that were actually present on the branch. The lockfile filled the entire diff window. This script sidesteps the transport layer entirely by reading files directly from git object storage.

## Test plan

- [ ] Run `./scripts/pr-contents.sh` on a branch with lockfile changes — confirm lockfile is skipped and source files shown in full
- [ ] Run `./scripts/pr-contents.sh issue-4-express-api main` — confirm all 15 source files are shown without truncation
- [ ] Verify `=== SUMMARY ===` line accurately counts shown vs skipped files
- [ ] Verify deleted files are flagged as `--- DELETED in this PR ---` rather than crashing

Closes #27