### PR TITLE
[cheese-hater] Add GET /roast — daily deterministic cheese roast generator

### DIFF
--- a/src/routes/roast.ts
+++ b/src/routes/roast.ts
@@ -1,0 +1,111 @@
+import { Router, Request, Response } from 'express'
+import ratingsData from '../data/cheese-ratings.json' with { type: 'json' }
+import factsData from '../data/cheese-facts.json' with { type: 'json' }
+
+const router = Router()
+
+interface RatedCheese {
+  id: number
+  name: string
+  origin: string
+  scores: { smell: number; texture: number; taste: number; cultural_damage: number }
+  aggregate: number
+  verdict: string
+  smell_note: string
+  texture_note: string
+  taste_note: string
+  cultural_damage_note: string
+  full_review: string
+  shareable_card: { title: string; score_display: string; verdict: string; one_liner: string }
+}
+
+interface Fact {
+  id: number
+  text: string
+  category: string
+  severity: number
+}
+
+const cheeses = (ratingsData as any).cheeses as RatedCheese[]
+const facts = (factsData as any).facts as Fact[]
+
+/**
+ * Deterministic day-seeded index — same date always picks the same cheese.
+ * Uses a simple djb2-style hash of the ISO date string (YYYY-MM-DD).
+ */
+function dateHash(dateStr: string): number {
+  let h = 5381
+  for (let i = 0; i < dateStr.length; i++) {
+    h = (h * 33) ^ dateStr.charCodeAt(i)
+  }
+  return Math.abs(h)
+}
+
+function getTodayString(): string {
+  return new Date().toISOString().split('T')[0] // "2026-03-23"
+}
+
+function pickTodaysCheese(dateStr: string): RatedCheese {
+  return cheeses[dateHash(dateStr) % cheeses.length]
+}
+
+/**
+ * Pick the most damning facts for today's cheese.
+ * Prefer high-severity facts; break ties deterministically using dateHash.
+ */
+function pickSupportingFacts(dateStr: string, count: number): Fact[] {
+  const seed = dateHash(dateStr)
+  const sorted = [...facts].sort((a, b) => {
+    if (b.severity !== a.severity) return b.severity - a.severity
+    return ((a.id * seed) % 997) - ((b.id * seed) % 997)
+  })
+  return sorted.slice(0, count)
+}
+
+function buildRoast(cheese: RatedCheese, supportingFacts: Fact[]): string {
+  const factLines = supportingFacts
+    .map(f => `Fact: ${f.text}`)
+    .join(' ')
+
+  return [
+    cheese.full_review,
+    `On smell: ${cheese.smell_note}`,
+    `On texture: ${cheese.texture_note}`,
+    `On taste: ${cheese.taste_note}`,
+    `On cultural damage: ${cheese.cultural_damage_note}`,
+    `And lest there be any doubt about cheese as a category — ${factLines}`,
+    `${cheese.name} earns a ${cheese.shareable_card.score_display}. The verdict is ${cheese.verdict}. ${cheese.shareable_card.one_liner}`,
+  ].join('\n\n')
+}
+
+// GET /roast — today's deterministic cheese roast
+router.get('/', (_req: Request, res: Response) => {
+  const dateStr = getTodayString()
+  const cheese = pickTodaysCheese(dateStr)
+  const supportingFacts = pickSupportingFacts(dateStr, 3)
+
+  res.json({
+    date: dateStr,
+    cheese_of_the_day: cheese.name,
+    origin: cheese.origin,
+    score: cheese.aggregate,
+    score_display: cheese.shareable_card.score_display,
+    verdict: cheese.verdict,
+    category_scores: {
+      smell: cheese.scores.smell,
+      texture: cheese.scores.texture,
+      taste: cheese.scores.taste,
+      cultural_damage: cheese.scores.cultural_damage,
+    },
+    roast: buildRoast(cheese, supportingFacts),
+    supporting_facts: supportingFacts.map(f => ({
+      text: f.text,
+      category: f.category,
+      severity: f.severity,
+    })),
+    note: 'A new cheese is roasted each day. All are equally condemned.',
+  })
+})
+
+export { getTodayString, pickTodaysCheese, pickSupportingFacts, buildRoast, dateHash, cheeses }
+export default router

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import rantRouter from './routes/rant'
 import counterRouter from './routes/counter'
 import rateRouter from './routes/rate'
 import factsRouter from './routes/facts'
+import roastRouter from './routes/roast'
 
 const app = express()
 const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000
@@ -36,6 +37,7 @@ app.get('/', (_req, res) => {
       'GET /rate':         'List all 20 rated cheeses and their verdicts',
       'GET /facts':        'Get a random damning cheese fact',
       'GET /facts/all':    'Get all facts unconditionally',
+      'GET /roast':        'Get today\'s daily cheese roast — a different cheese condemned each day',
       'GET /health':       'Confirm the agent is operational and hates cheese',
     },
     note: 'No cheese has ever scored above 1.5/10. No cheese ever will.',
@@ -57,11 +59,14 @@ app.use('/rate', rateRouter)
 // GET /facts — a random damning cheese fact
 app.use('/facts', factsRouter)
 
+// GET /roast — today's deterministic daily cheese roast
+app.use('/roast', roastRouter)
+
 // 404 handler
 app.use((_req, res) => {
   res.status(404).json({
     error: 'Endpoint not found.',
-    available: ['POST /opinion', 'GET /random-rant', 'GET /counter/:argument', 'GET /rate/:cheese', 'GET /facts'],
+    available: ['POST /opinion', 'GET /random-rant', 'GET /counter/:argument', 'GET /rate/:cheese', 'GET /facts', 'GET /roast'],
     note: 'All endpoints hate cheese. That is the only guarantee.',
   })
 })

--- a/src/tests/roast.test.ts
+++ b/src/tests/roast.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import app from '../server.js'
+import {
+  dateHash,
+  getTodayString,
+  pickTodaysCheese,
+  pickSupportingFacts,
+  buildRoast,
+  cheeses,
+} from '../routes/roast.js'
+
+describe('GET /roast', () => {
+  it('returns 200 with the required fields', async () => {
+    const res = await request(app).get('/roast')
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveProperty('date')
+    expect(res.body).toHaveProperty('cheese_of_the_day')
+    expect(res.body).toHaveProperty('origin')
+    expect(res.body).toHaveProperty('score')
+    expect(res.body).toHaveProperty('score_display')
+    expect(res.body).toHaveProperty('verdict')
+    expect(res.body).toHaveProperty('category_scores')
+    expect(res.body).toHaveProperty('roast')
+    expect(res.body).toHaveProperty('supporting_facts')
+    expect(res.body).toHaveProperty('note')
+  })
+
+  it('returns a date string in YYYY-MM-DD format', async () => {
+    const res = await request(app).get('/roast')
+    expect(res.body.date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('returns a known cheese name', async () => {
+    const res = await request(app).get('/roast')
+    const knownNames = cheeses.map((c: any) => c.name)
+    expect(knownNames).toContain(res.body.cheese_of_the_day)
+  })
+
+  it('returns a score below 10 (all cheese is terrible)', async () => {
+    const res = await request(app).get('/roast')
+    expect(res.body.score).toBeLessThan(10)
+  })
+
+  it('returns exactly 3 supporting facts', async () => {
+    const res = await request(app).get('/roast')
+    expect(res.body.supporting_facts).toHaveLength(3)
+  })
+
+  it('supporting facts have required fields', async () => {
+    const res = await request(app).get('/roast')
+    for (const fact of res.body.supporting_facts) {
+      expect(fact).toHaveProperty('text')
+      expect(fact).toHaveProperty('category')
+      expect(fact).toHaveProperty('severity')
+    }
+  })
+
+  it('roast is a non-empty multi-paragraph string', async () => {
+    const res = await request(app).get('/roast')
+    expect(typeof res.body.roast).toBe('string')
+    expect(res.body.roast.length).toBeGreaterThan(200)
+    expect(res.body.roast).toContain('\n\n')
+  })
+
+  it('category_scores has all four dimensions', async () => {
+    const res = await request(app).get('/roast')
+    expect(res.body.category_scores).toHaveProperty('smell')
+    expect(res.body.category_scores).toHaveProperty('texture')
+    expect(res.body.category_scores).toHaveProperty('taste')
+    expect(res.body.category_scores).toHaveProperty('cultural_damage')
+  })
+
+  it('is deterministic — same date always returns same cheese', async () => {
+    const res1 = await request(app).get('/roast')
+    const res2 = await request(app).get('/roast')
+    expect(res1.body.cheese_of_the_day).toBe(res2.body.cheese_of_the_day)
+    expect(res1.body.date).toBe(res2.body.date)
+  })
+})
+
+describe('dateHash', () => {
+  it('returns a non-negative integer', () => {
+    expect(dateHash('2026-03-23')).toBeGreaterThanOrEqual(0)
+    expect(Number.isInteger(dateHash('2026-03-23'))).toBe(true)
+  })
+
+  it('is deterministic for the same input', () => {
+    expect(dateHash('2026-03-23')).toBe(dateHash('2026-03-23'))
+  })
+
+  it('produces different values for different dates', () => {
+    expect(dateHash('2026-03-23')).not.toBe(dateHash('2026-03-24'))
+    expect(dateHash('2026-03-23')).not.toBe(dateHash('2026-04-23'))
+  })
+})
+
+describe('pickTodaysCheese', () => {
+  it('always returns a cheese from the list', () => {
+    const known = cheeses.map((c: any) => c.name)
+    for (const date of ['2026-01-01', '2026-06-15', '2026-12-31', '2027-03-23']) {
+      const cheese = pickTodaysCheese(date)
+      expect(known).toContain(cheese.name)
+    }
+  })
+
+  it('cycles through different cheeses on different dates', () => {
+    const dates = Array.from({ length: 30 }, (_, i) => `2026-01-${String(i + 1).padStart(2, '0')}`)
+    const picked = new Set(dates.map(d => pickTodaysCheese(d).name))
+    expect(picked.size).toBeGreaterThan(1)
+  })
+})
+
+describe('pickSupportingFacts', () => {
+  it('returns the requested number of facts', () => {
+    expect(pickSupportingFacts('2026-03-23', 3)).toHaveLength(3)
+    expect(pickSupportingFacts('2026-03-23', 5)).toHaveLength(5)
+  })
+
+  it('prefers high-severity facts', () => {
+    const facts = pickSupportingFacts('2026-03-23', 5)
+    const minSeverity = Math.min(...facts.map(f => f.severity))
+    expect(minSeverity).toBeGreaterThanOrEqual(4)
+  })
+
+  it('is deterministic for the same date', () => {
+    const a = pickSupportingFacts('2026-03-23', 3).map(f => f.id)
+    const b = pickSupportingFacts('2026-03-23', 3).map(f => f.id)
+    expect(a).toEqual(b)
+  })
+})
+
+describe('buildRoast', () => {
+  it('includes all review sections', () => {
+    const cheese = pickTodaysCheese('2026-03-23')
+    const facts = pickSupportingFacts('2026-03-23', 3)
+    const roast = buildRoast(cheese, facts)
+    expect(roast).toContain(cheese.full_review)
+    expect(roast).toContain(cheese.smell_note)
+    expect(roast).toContain(cheese.texture_note)
+    expect(roast).toContain(cheese.taste_note)
+    expect(roast).toContain(cheese.cultural_damage_note)
+  })
+
+  it('includes the verdict and score', () => {
+    const cheese = pickTodaysCheese('2026-03-23')
+    const facts = pickSupportingFacts('2026-03-23', 3)
+    const roast = buildRoast(cheese, facts)
+    expect(roast).toContain(cheese.verdict)
+    expect(roast).toContain(cheese.shareable_card.score_display)
+  })
+})
+
+describe('getTodayString', () => {
+  it('returns a YYYY-MM-DD formatted string', () => {
+    expect(getTodayString()).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `GET /roast` endpoint that returns today's cheese roast
- Cheese selection is **deterministic per day**: a djb2 hash of the ISO date string (`YYYY-MM-DD`) seeds the index into the 21-cheese ratings database — same date always returns same cheese, different day picks a different one
- Selects the 3 most damning supporting facts (highest severity, tie-broken deterministically by date hash)
- Builds a multi-paragraph roast from the cheese's `full_review`, `smell_note`, `texture_note`, `taste_note`, `cultural_damage_note`, supporting facts, and a closing verdict line
- Response includes: `date`, `cheese_of_the_day`, `origin`, `score`, `score_display`, `verdict`, `category_scores` (all 4 dimensions), `roast`, `supporting_facts`, `note`

## Test plan

- [ ] `GET /roast` returns 200 with all required fields
- [ ] Date field matches `YYYY-MM-DD` format
- [ ] Returned cheese is a known rated cheese
- [ ] Score is below 10 (all cheese is terrible)
- [ ] Exactly 3 supporting facts with `text`, `category`, `severity`
- [ ] Roast is multi-paragraph (contains `\n\n`) and > 200 chars
- [ ] Two calls on same day return identical cheese (determinism)
- [ ] `dateHash` is deterministic, non-negative, and varies across dates
- [ ] `pickTodaysCheese` covers different cheeses across 30 consecutive dates
- [ ] `pickSupportingFacts` prefers severity ≥ 4 facts
- [ ] `buildRoast` includes all review sections and the verdict

Run: `npm test` → 94/94 pass

Closes #45