### PR TITLE
[cheese-hater] Add GET /roast/versus — cheese head-to-head roast comparison

### DIFF
--- a/src/routes/roast.ts
+++ b/src/routes/roast.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express'
 import ratingsData from '../data/cheese-ratings.json' with { type: 'json' }
 import factsData from '../data/cheese-facts.json' with { type: 'json' }
+import { rateCheese } from '../lib/cheeseHater.js'
 
 const router = Router()
 
@@ -90,6 +91,90 @@ function dateStringDaysAgo(daysAgo: number): string {
   d.setUTCDate(d.getUTCDate() - daysAgo)
   return d.toISOString().split('T')[0]
 }
+
+/**
+ * Build a focused versus roast for a single cheese: full review + one-liner verdict.
+ * Shorter than buildRoast() — designed to be read side-by-side.
+ */
+function buildVersusRoast(name: string): {
+  cheese: string
+  score: number
+  score_display: string
+  verdict: string
+  roast: string
+  known: boolean
+} {
+  const rating = rateCheese(name)
+  const isKnown = cheeses.some(c => c.name.toLowerCase() === name.toLowerCase().trim())
+  const full = cheeses.find(c => c.name.toLowerCase() === name.toLowerCase().trim())
+  const roastParagraphs: string[] = [rating.review]
+  if (full) {
+    roastParagraphs.push(`On smell: ${full.smell_note}`)
+    roastParagraphs.push(`Verdict: ${full.shareable_card.one_liner}`)
+  }
+  return {
+    cheese: rating.name,
+    score: rating.score,
+    score_display: `${rating.score}/10`,
+    verdict: rating.verdict,
+    roast: roastParagraphs.join('\n\n'),
+    known: isKnown,
+  }
+}
+
+// GET /roast/versus?a=<cheese>&b=<cheese> — pit two cheeses against each other
+router.get('/versus', (req: Request, res: Response) => {
+  const { a, b } = req.query
+
+  if (!a || !b || typeof a !== 'string' || typeof b !== 'string') {
+    res.status(400).json({
+      error: 'Both `a` and `b` query parameters are required.',
+      example: '/roast/versus?a=brie&b=gouda',
+    })
+    return
+  }
+
+  const nameA = a.trim()
+  const nameB = b.trim()
+
+  if (nameA.toLowerCase() === nameB.toLowerCase()) {
+    res.status(400).json({
+      error: 'Comparing a cheese to itself is redundant. It is already condemned on its own merits.',
+    })
+    return
+  }
+
+  const roastA = buildVersusRoast(nameA)
+  const roastB = buildVersusRoast(nameB)
+
+  let loser: string
+  let winner: string
+  let margin: number
+  let declaration: string
+
+  if (roastA.score < roastB.score) {
+    loser = roastA.cheese
+    winner = roastB.cheese
+    margin = Number((roastB.score - roastA.score).toFixed(2))
+    declaration = `${roastA.cheese} is the worse offender by a margin of ${margin} points. Both are terrible. ${roastA.cheese} has simply achieved a new depth of terrible.`
+  } else if (roastB.score < roastA.score) {
+    loser = roastB.cheese
+    winner = roastA.cheese
+    margin = Number((roastA.score - roastB.score).toFixed(2))
+    declaration = `${roastB.cheese} is the worse offender by a margin of ${margin} points. Both are terrible. ${roastB.cheese} has simply achieved a new depth of terrible.`
+  } else {
+    loser = 'both'
+    winner = 'neither'
+    margin = 0
+    declaration = `${roastA.cheese} and ${roastB.cheese} are equally terrible, which is itself a damning result. They have tied for last place in a competition where last place is the only place.`
+  }
+
+  res.json({
+    verdict: { loser, winner, margin, declaration },
+    contestants: { a: roastA, b: roastB },
+    note: 'In a contest between two cheeses, the real loser is whoever is eating them.',
+  })
+})
 
 // GET /roast/history?days=N — last N days of roasted cheeses (default 7, max 30)
 router.get('/history', (req: Request, res: Response) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,6 +39,7 @@ app.get('/', (_req, res) => {
       'GET /facts/all':    'Get all facts unconditionally',
       'GET /roast':        'Get today\'s daily cheese roast — a different cheese condemned each day',
       'GET /roast/history':'Browse past N days of roasted cheeses (default 7, max 30)',
+      'GET /roast/versus': 'Pit two cheeses against each other — declare the worse offender',
       'GET /health':       'Confirm the agent is operational and hates cheese',
     },
     note: 'No cheese has ever scored above 1.5/10. No cheese ever will.',

--- a/src/tests/roastVersus.test.ts
+++ b/src/tests/roastVersus.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import app from '../server.js'
+
+describe('GET /roast/versus', () => {
+  it('returns 200 with required envelope fields', async () => {
+    const res = await request(app).get('/roast/versus?a=brie&b=gouda')
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveProperty('verdict')
+    expect(res.body).toHaveProperty('contestants')
+    expect(res.body).toHaveProperty('note')
+  })
+
+  it('verdict has loser, winner, margin, declaration', async () => {
+    const res = await request(app).get('/roast/versus?a=brie&b=gouda')
+    expect(res.body.verdict).toHaveProperty('loser')
+    expect(res.body.verdict).toHaveProperty('winner')
+    expect(res.body.verdict).toHaveProperty('margin')
+    expect(res.body.verdict).toHaveProperty('declaration')
+    expect(typeof res.body.verdict.declaration).toBe('string')
+    expect(res.body.verdict.declaration.length).toBeGreaterThan(20)
+  })
+
+  it('contestants.a and contestants.b have required fields', async () => {
+    const res = await request(app).get('/roast/versus?a=brie&b=cheddar')
+    for (const key of ['a', 'b']) {
+      const c = res.body.contestants[key]
+      expect(c).toHaveProperty('cheese')
+      expect(c).toHaveProperty('score')
+      expect(c).toHaveProperty('score_display')
+      expect(c).toHaveProperty('verdict')
+      expect(c).toHaveProperty('roast')
+      expect(c).toHaveProperty('known')
+    }
+  })
+
+  it('identifies the lower-scoring cheese as the loser', async () => {
+    const res = await request(app).get('/roast/versus?a=brie&b=cheddar')
+    const { a, b } = res.body.contestants
+    const { loser } = res.body.verdict
+    if (a.score < b.score) {
+      expect(loser).toBe(a.cheese)
+    } else if (b.score < a.score) {
+      expect(loser).toBe(b.cheese)
+    } else {
+      expect(loser).toBe('both')
+    }
+  })
+
+  it('margin is the absolute score difference', async () => {
+    const res = await request(app).get('/roast/versus?a=blue+cheese&b=parmesan')
+    const { a, b } = res.body.contestants
+    const expected = Math.abs(Number((a.score - b.score).toFixed(2)))
+    expect(res.body.verdict.margin).toBeCloseTo(expected, 2)
+  })
+
+  it('handles unknown cheese names gracefully', async () => {
+    const res = await request(app).get('/roast/versus?a=mystery-wheel&b=brie')
+    expect(res.status).toBe(200)
+    expect(res.body.contestants.a.known).toBe(false)
+    expect(res.body.contestants.b.known).toBe(true)
+    expect(res.body.contestants.a.verdict).toBe('CONDEMNED')
+    expect(typeof res.body.contestants.a.roast).toBe('string')
+  })
+
+  it('handles two unknown cheeses', async () => {
+    const res = await request(app).get('/roast/versus?a=phantom-brie&b=shadow-gouda')
+    expect(res.status).toBe(200)
+    expect(res.body.contestants.a.known).toBe(false)
+    expect(res.body.contestants.b.known).toBe(false)
+    expect(res.body.verdict.loser).toBe('both') // tie at 1.0 each
+  })
+
+  it('roast text is a non-empty string', async () => {
+    const res = await request(app).get('/roast/versus?a=mozzarella&b=gruyere')
+    expect(res.body.contestants.a.roast.length).toBeGreaterThan(50)
+    expect(res.body.contestants.b.roast.length).toBeGreaterThan(50)
+  })
+
+  it('known cheeses include multi-paragraph roast (contains newlines)', async () => {
+    const res = await request(app).get('/roast/versus?a=brie&b=stilton')
+    expect(res.body.contestants.a.roast).toContain('\n\n')
+    expect(res.body.contestants.b.roast).toContain('\n\n')
+  })
+
+  it('returns 400 when a is missing', async () => {
+    const res = await request(app).get('/roast/versus?b=gouda')
+    expect(res.status).toBe(400)
+    expect(res.body).toHaveProperty('error')
+    expect(res.body).toHaveProperty('example')
+  })
+
+  it('returns 400 when b is missing', async () => {
+    const res = await request(app).get('/roast/versus?a=brie')
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when both params are missing', async () => {
+    const res = await request(app).get('/roast/versus')
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when a and b are the same cheese', async () => {
+    const res = await request(app).get('/roast/versus?a=brie&b=brie')
+    expect(res.status).toBe(400)
+    expect(res.body.error).toContain('itself')
+  })
+
+  it('is case-insensitive for same-cheese detection', async () => {
+    const res = await request(app).get('/roast/versus?a=Brie&b=brie')
+    expect(res.status).toBe(400)
+  })
+
+  it('is deterministic — same cheeses always return same result', async () => {
+    const res1 = await request(app).get('/roast/versus?a=brie&b=cheddar')
+    const res2 = await request(app).get('/roast/versus?a=brie&b=cheddar')
+    expect(res1.body.verdict).toEqual(res2.body.verdict)
+    expect(res1.body.contestants.a.score).toBe(res2.body.contestants.a.score)
+  })
+
+  it('declaration names the loser', async () => {
+    const res = await request(app).get('/roast/versus?a=brie&b=blue+cheese')
+    const { declaration, loser } = res.body.verdict
+    if (loser !== 'both') {
+      expect(declaration).toContain(loser)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `GET /roast/versus?a=<cheese>&b=<cheese>` — pits two cheeses against each other and declares the worse offender
- Lower aggregate score = more condemned = loser (scores in this API are always terrible, but some are more terrible than others)
- Handles unknown cheese names gracefully: `rateCheese()` returns a `CONDEMNED` fallback at 1.0/10, flagged with `known: false`
- Two unknowns tie at 1.0 → `loser: 'both'`, `winner: 'neither'`
- Same-cheese comparison → 400 with clear error message
- Missing either param → 400 with usage example

## Response shape

```json
{
  "verdict": {
    "loser": "Brie",
    "winner": "Gouda",
    "margin": 0.35,
    "declaration": "Brie is the worse offender by a margin of 0.35 points..."
  },
  "contestants": {
    "a": { "cheese": "Brie", "score": 1.65, "score_display": "1.65/10", "verdict": "REVOLTING", "roast": "...", "known": true },
    "b": { "cheese": "Gouda", "score": 2.0, "score_display": "2.0/10", "verdict": "CONDEMNED", "roast": "...", "known": true }
  },
  "note": "In a contest between two cheeses, the real loser is whoever is eating them."
}
```

## Test plan

- [ ] 200 with correct envelope fields
- [ ] `verdict` has loser/winner/margin/declaration
- [ ] Contestants have cheese/score/score_display/verdict/roast/known
- [ ] Lower-scoring cheese is declared loser
- [ ] Margin equals absolute score difference
- [ ] Unknown cheese → 200, `known: false`, CONDEMNED verdict
- [ ] Two unknowns → tie, `loser: 'both'`
- [ ] Known cheeses have multi-paragraph roast (contains `\n\n`)
- [ ] Missing `a` or `b` → 400
- [ ] Same cheese → 400 with "itself" in error
- [ ] Case-insensitive same-cheese detection
- [ ] Deterministic — same inputs always same result
- [ ] Declaration names the loser

Run: `npm test` → 110/110 pass

Closes #51