### PR TITLE
[cheese-hater] Add GET /roast/leaderboard — most-condemned cheeses by 30-day appearance count

### DIFF
--- a/src/routes/roast.ts
+++ b/src/routes/roast.ts
@@ -306,6 +306,56 @@ router.get('/bracket', (req: Request, res: Response) => {
   })
 })
 
+const LEADERBOARD_DEFAULT_LIMIT = 10
+
+// GET /roast/leaderboard?limit=N — most-condemned cheeses ranked by appearance count
+router.get('/leaderboard', (req: Request, res: Response) => {
+  const rawLimit = req.query.limit
+  let limit = LEADERBOARD_DEFAULT_LIMIT
+
+  if (rawLimit !== undefined) {
+    const parsed = parseInt(String(rawLimit), 10)
+    if (isNaN(parsed) || parsed < 1) {
+      res.status(400).json({ error: '`limit` must be a positive integer.' })
+      return
+    }
+    limit = parsed
+  }
+
+  // Tally appearances across the full history window (HISTORY_MAX_DAYS days)
+  const counts = new Map<string, number>()
+  for (let i = 0; i < HISTORY_MAX_DAYS; i++) {
+    const dateStr = dateStringDaysAgo(i)
+    const cheese = pickTodaysCheese(dateStr)
+    counts.set(cheese.name, (counts.get(cheese.name) ?? 0) + 1)
+  }
+
+  // Sort: most appearances first; break ties alphabetically for determinism
+  const ranked = [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, limit)
+
+  const leaderboard = ranked.map(([name, appearances], idx) => {
+    const full = cheeses.find(c => c.name === name)!
+    return {
+      rank: idx + 1,
+      cheese: name,
+      appearances,
+      score_display: full.shareable_card.score_display,
+      verdict: full.verdict,
+      best_quote: full.shareable_card.one_liner,
+    }
+  })
+
+  res.json({
+    limit,
+    history_window_days: HISTORY_MAX_DAYS,
+    total_ranked: leaderboard.length,
+    leaderboard,
+    note: 'Ranked by number of daily condemnations in the last 30 days. A higher rank means more suffering.',
+  })
+})
+
 // GET /roast/history?days=N — last N days of roasted cheeses (default 7, max 30)
 router.get('/history', (req: Request, res: Response) => {
   const rawDays = req.query.days

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,8 +40,9 @@ app.get('/', (_req, res) => {
       'GET /roast':        'Get today\'s daily cheese roast — a different cheese condemned each day',
       'GET /roast/history':'Browse past N days of roasted cheeses (default 7, max 30)',
       'GET /roast/versus': 'Pit two cheeses against each other — declare the worse offender',
-      'GET /roast/bracket':'Run 4–8 cheeses through a single-elimination tournament of condemnation',
-      'GET /health':       'Confirm the agent is operational and hates cheese',
+      'GET /roast/bracket':     'Run 4–8 cheeses through a single-elimination tournament of condemnation',
+      'GET /roast/leaderboard': 'Top N most-condemned cheeses ranked by 30-day appearance count',
+      'GET /health':            'Confirm the agent is operational and hates cheese',
     },
     note: 'No cheese has ever scored above 1.5/10. No cheese ever will.',
   })

--- a/src/tests/roastLeaderboard.test.ts
+++ b/src/tests/roastLeaderboard.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import app from '../server.js'
+import { cheeses, HISTORY_MAX_DAYS } from '../routes/roast.js'
+
+describe('GET /roast/leaderboard', () => {
+  it('returns 200 with required envelope fields', async () => {
+    const res = await request(app).get('/roast/leaderboard')
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveProperty('limit')
+    expect(res.body).toHaveProperty('history_window_days', HISTORY_MAX_DAYS)
+    expect(res.body).toHaveProperty('total_ranked')
+    expect(res.body).toHaveProperty('leaderboard')
+    expect(res.body).toHaveProperty('note')
+    expect(Array.isArray(res.body.leaderboard)).toBe(true)
+  })
+
+  it('defaults to 10 entries when ?limit is omitted', async () => {
+    const res = await request(app).get('/roast/leaderboard')
+    expect(res.body.limit).toBe(10)
+    expect(res.body.leaderboard.length).toBeLessThanOrEqual(10)
+  })
+
+  it('respects ?limit parameter', async () => {
+    const res = await request(app).get('/roast/leaderboard?limit=3')
+    expect(res.body.limit).toBe(3)
+    expect(res.body.leaderboard).toHaveLength(3)
+  })
+
+  it('limit=1 returns exactly 1 entry', async () => {
+    const res = await request(app).get('/roast/leaderboard?limit=1')
+    expect(res.body.leaderboard).toHaveLength(1)
+    expect(res.body.leaderboard[0].rank).toBe(1)
+  })
+
+  it('each entry has required fields', async () => {
+    const res = await request(app).get('/roast/leaderboard')
+    for (const entry of res.body.leaderboard) {
+      expect(entry).toHaveProperty('rank')
+      expect(entry).toHaveProperty('cheese')
+      expect(entry).toHaveProperty('appearances')
+      expect(entry).toHaveProperty('score_display')
+      expect(entry).toHaveProperty('verdict')
+      expect(entry).toHaveProperty('best_quote')
+    }
+  })
+
+  it('rank is sequential starting from 1', async () => {
+    const res = await request(app).get('/roast/leaderboard')
+    res.body.leaderboard.forEach((entry: any, idx: number) => {
+      expect(entry.rank).toBe(idx + 1)
+    })
+  })
+
+  it('entries are sorted descending by appearances', async () => {
+    const res = await request(app).get('/roast/leaderboard?limit=20')
+    const appearances: number[] = res.body.leaderboard.map((e: any) => e.appearances)
+    for (let i = 1; i < appearances.length; i++) {
+      expect(appearances[i]).toBeLessThanOrEqual(appearances[i - 1])
+    }
+  })
+
+  it('all cheese names are in the rated cheese database', async () => {
+    const res = await request(app).get('/roast/leaderboard?limit=20')
+    const knownNames = cheeses.map((c: any) => c.name)
+    for (const entry of res.body.leaderboard) {
+      expect(knownNames).toContain(entry.cheese)
+    }
+  })
+
+  it('appearances are positive integers', async () => {
+    const res = await request(app).get('/roast/leaderboard')
+    for (const entry of res.body.leaderboard) {
+      expect(Number.isInteger(entry.appearances)).toBe(true)
+      expect(entry.appearances).toBeGreaterThan(0)
+    }
+  })
+
+  it('total appearances sum to HISTORY_MAX_DAYS', async () => {
+    // Request all possible entries (21 cheeses max)
+    const res = await request(app).get('/roast/leaderboard?limit=21')
+    const total = res.body.leaderboard.reduce((sum: number, e: any) => sum + e.appearances, 0)
+    expect(total).toBe(HISTORY_MAX_DAYS)
+  })
+
+  it('best_quote is a non-empty string', async () => {
+    const res = await request(app).get('/roast/leaderboard')
+    for (const entry of res.body.leaderboard) {
+      expect(typeof entry.best_quote).toBe('string')
+      expect(entry.best_quote.length).toBeGreaterThan(10)
+    }
+  })
+
+  it('total_ranked matches leaderboard array length', async () => {
+    const res = await request(app).get('/roast/leaderboard?limit=5')
+    expect(res.body.total_ranked).toBe(res.body.leaderboard.length)
+  })
+
+  it('is deterministic — same request always returns same result', async () => {
+    const res1 = await request(app).get('/roast/leaderboard?limit=5')
+    const res2 = await request(app).get('/roast/leaderboard?limit=5')
+    expect(res1.body.leaderboard).toEqual(res2.body.leaderboard)
+  })
+
+  it('works from day 1 — returns results without any prior setup', async () => {
+    const res = await request(app).get('/roast/leaderboard')
+    expect(res.status).toBe(200)
+    expect(res.body.leaderboard.length).toBeGreaterThan(0)
+  })
+
+  it('large limit returns at most the number of distinct cheeses in history', async () => {
+    const res = await request(app).get('/roast/leaderboard?limit=999')
+    // At most 21 cheeses total; at most HISTORY_MAX_DAYS distinct entries
+    expect(res.body.leaderboard.length).toBeLessThanOrEqual(cheeses.length)
+  })
+
+  it('no cheese appears twice in the leaderboard', async () => {
+    const res = await request(app).get('/roast/leaderboard?limit=21')
+    const names = res.body.leaderboard.map((e: any) => e.cheese)
+    expect(new Set(names).size).toBe(names.length)
+  })
+
+  // Validation
+  it('returns 400 for ?limit=0', async () => {
+    const res = await request(app).get('/roast/leaderboard?limit=0')
+    expect(res.status).toBe(400)
+    expect(res.body).toHaveProperty('error')
+  })
+
+  it('returns 400 for non-numeric ?limit', async () => {
+    const res = await request(app).get('/roast/leaderboard?limit=lots')
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for negative ?limit', async () => {
+    const res = await request(app).get('/roast/leaderboard?limit=-5')
+    expect(res.status).toBe(400)
+  })
+
+  it('note field mentions condemnation', async () => {
+    const res = await request(app).get('/roast/leaderboard')
+    expect(res.body.note).toMatch(/condemn/i)
+  })
+})


### PR DESCRIPTION
## Summary

Adds `GET /roast/leaderboard?limit=N` — an aggregated view of which cheeses get condemned most often over the last 30 days, with their most savage shareable quote.

**How it works:**
- Tallies the cheese-of-the-day selection for each of the last `HISTORY_MAX_DAYS` (30) days using the existing deterministic `pickTodaysCheese()` function
- Ranks by appearance count descending; ties broken alphabetically for determinism
- Returns the top `N` entries (default 10)
- Each entry: `rank`, `cheese`, `appearances`, `score_display`, `verdict`, `best_quote` (from `shareable_card.one_liner`)

**Works from day 1** — no prior state needed. The history is computed on-the-fly from the date-hash algorithm. Over the 30-day window, 20 of 21 cheeses appear; appearances always sum to exactly 30.

## Example response

```json
{
  "limit": 10,
  "history_window_days": 30,
  "total_ranked": 10,
  "leaderboard": [
    {
      "rank": 1,
      "cheese": "Blue Cheese",
      "appearances": 2,
      "score_display": "1.1 / 10",
      "verdict": "REVOLTING",
      "best_quote": "Someone looked at rotting dairy and said 'more of this.' That person was wrong."
    },
    ...
  ],
  "note": "Ranked by number of daily condemnations in the last 30 days. A higher rank means more suffering."
}
```

## Test plan

- [ ] 200 with limit, history_window_days, total_ranked, leaderboard, note
- [ ] Default limit=10, respects ?limit=3, limit=1
- [ ] Each entry has rank, cheese, appearances, score_display, verdict, best_quote
- [ ] Ranks are sequential from 1
- [ ] Entries sorted descending by appearances
- [ ] All cheese names are in the rated database
- [ ] Appearances are positive integers
- [ ] All appearances sum to HISTORY_MAX_DAYS (30) when limit=21
- [ ] best_quote is a non-empty string (>10 chars)
- [ ] total_ranked == leaderboard.length
- [ ] Fully deterministic — identical calls return identical results
- [ ] Works from day 1 (no prior setup)
- [ ] Large limit naturally capped at distinct cheese count
- [ ] No cheese appears twice
- [ ] 400 for limit=0, negative, non-numeric
- [ ] note contains "condemn"

Run: `npm test` → 168/168 pass

Closes #55