### PR TITLE
[cheese-hater] Add interactive HTML API explorer at GET /

### DIFF
--- a/src/lib/explorerHtml.ts
+++ b/src/lib/explorerHtml.ts
@@ -1,0 +1,650 @@
+/**
+ * Generates the interactive HTML API explorer page.
+ *
+ * No external dependencies. No CDN. No build step.
+ * Pure inline HTML/CSS/JS — served only when the browser
+ * sends Accept: text/html.
+ *
+ * The explorer fetches /api at runtime, renders every endpoint
+ * with a "Try it" button, and displays live responses inline.
+ * Every pixel of it hates cheese.
+ */
+export function generateExplorerHtml(): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>cheese-hater API — I Hate Cheese</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #0d0d0d;
+      --surface: #161616;
+      --surface2: #1f1f1f;
+      --border: #2a2a2a;
+      --accent: #c0392b;
+      --accent-dim: #7b241c;
+      --accent-hover: #e74c3c;
+      --text: #e8e8e8;
+      --text-dim: #888;
+      --text-muted: #555;
+      --green: #27ae60;
+      --yellow: #f39c12;
+      --code-bg: #111;
+      --radius: 6px;
+      --font-mono: 'Courier New', Courier, monospace;
+    }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-size: 15px;
+      line-height: 1.6;
+      min-height: 100vh;
+    }
+
+    /* ── Header ── */
+    header {
+      background: var(--surface);
+      border-bottom: 2px solid var(--accent);
+      padding: 28px 32px 24px;
+    }
+    .header-inner {
+      max-width: 900px;
+      margin: 0 auto;
+    }
+    h1 {
+      font-size: 2rem;
+      font-weight: 800;
+      letter-spacing: -0.5px;
+      color: var(--accent);
+      margin-bottom: 4px;
+    }
+    .tagline {
+      color: var(--text-dim);
+      font-size: 0.95rem;
+      margin-top: 6px;
+    }
+    .hatred-badge {
+      display: inline-block;
+      margin-top: 12px;
+      background: var(--accent);
+      color: #fff;
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+      padding: 3px 10px;
+      border-radius: 3px;
+    }
+
+    /* ── Layout ── */
+    main {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 32px 24px 64px;
+    }
+
+    /* ── Manifesto banner ── */
+    .manifesto {
+      background: var(--surface);
+      border: 1px solid var(--accent-dim);
+      border-left: 4px solid var(--accent);
+      border-radius: var(--radius);
+      padding: 18px 20px;
+      margin-bottom: 32px;
+      font-size: 0.9rem;
+      color: var(--text-dim);
+      line-height: 1.7;
+    }
+    .manifesto strong {
+      color: var(--text);
+    }
+
+    /* ── Section header ── */
+    .section-title {
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      margin-bottom: 14px;
+      padding-bottom: 8px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    /* ── Endpoint cards ── */
+    .endpoint-list {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .endpoint-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+
+    .endpoint-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 14px 16px;
+      cursor: pointer;
+      user-select: none;
+      transition: background 0.15s;
+    }
+    .endpoint-header:hover {
+      background: var(--surface2);
+    }
+
+    .method-badge {
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 0.5px;
+      padding: 3px 8px;
+      border-radius: 3px;
+      min-width: 48px;
+      text-align: center;
+      flex-shrink: 0;
+    }
+    .method-GET    { background: #1a3a2a; color: #4ade80; }
+    .method-POST   { background: #2a2010; color: #fbbf24; }
+    .method-PUT    { background: #1a2a3a; color: #60a5fa; }
+    .method-PATCH  { background: #2a1a3a; color: #c084fc; }
+    .method-DELETE { background: #3a1a1a; color: #f87171; }
+
+    .endpoint-path {
+      font-family: var(--font-mono);
+      font-size: 0.92rem;
+      color: var(--text);
+      flex: 1;
+    }
+    .endpoint-path .param-seg {
+      color: var(--yellow);
+    }
+
+    .endpoint-desc-short {
+      font-size: 0.82rem;
+      color: var(--text-dim);
+      flex: 2;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .chevron {
+      color: var(--text-muted);
+      font-size: 0.8rem;
+      transition: transform 0.2s;
+      flex-shrink: 0;
+    }
+    .endpoint-card.open .chevron { transform: rotate(90deg); }
+
+    /* ── Expanded panel ── */
+    .endpoint-body {
+      display: none;
+      border-top: 1px solid var(--border);
+      padding: 18px 16px;
+      background: var(--code-bg);
+    }
+    .endpoint-card.open .endpoint-body { display: block; }
+
+    .endpoint-desc-full {
+      font-size: 0.88rem;
+      color: var(--text-dim);
+      margin-bottom: 16px;
+      line-height: 1.6;
+    }
+
+    /* ── Try-it panel ── */
+    .try-it {
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 14px 16px;
+      margin-bottom: 14px;
+    }
+    .try-it-title {
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 1.5px;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      margin-bottom: 12px;
+    }
+
+    .param-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 10px;
+      flex-wrap: wrap;
+    }
+    .param-label {
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      color: var(--yellow);
+      min-width: 100px;
+      flex-shrink: 0;
+    }
+    .param-label .param-required {
+      color: var(--accent);
+      margin-left: 2px;
+    }
+    .param-input {
+      flex: 1;
+      min-width: 160px;
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--text);
+      font-family: var(--font-mono);
+      font-size: 0.83rem;
+      padding: 6px 10px;
+      outline: none;
+      transition: border-color 0.15s;
+    }
+    .param-input:focus { border-color: var(--accent); }
+    .param-desc {
+      font-size: 0.78rem;
+      color: var(--text-muted);
+      flex-basis: 100%;
+      padding-left: 110px;
+      margin-top: -6px;
+    }
+
+    .body-textarea {
+      width: 100%;
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--text);
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      padding: 8px 10px;
+      resize: vertical;
+      min-height: 80px;
+      outline: none;
+      margin-bottom: 10px;
+      transition: border-color 0.15s;
+    }
+    .body-textarea:focus { border-color: var(--accent); }
+
+    .try-btn {
+      background: var(--accent);
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      padding: 8px 20px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    .try-btn:hover { background: var(--accent-hover); }
+    .try-btn:active { background: var(--accent-dim); }
+    .try-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    /* ── Response block ── */
+    .response-block {
+      display: none;
+      margin-top: 12px;
+    }
+    .response-block.visible { display: block; }
+
+    .response-meta {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 8px;
+    }
+    .status-badge {
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      font-weight: 700;
+      padding: 2px 8px;
+      border-radius: 3px;
+    }
+    .status-2xx { background: #1a3a2a; color: #4ade80; }
+    .status-4xx { background: #3a2a10; color: #fbbf24; }
+    .status-5xx { background: #3a1a1a; color: #f87171; }
+    .status-err { background: #3a1a1a; color: #f87171; }
+
+    .response-label {
+      font-size: 0.72rem;
+      color: var(--text-muted);
+      letter-spacing: 1px;
+      text-transform: uppercase;
+    }
+
+    pre.response-body {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 12px 14px;
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      color: var(--text);
+      overflow-x: auto;
+      white-space: pre-wrap;
+      word-break: break-word;
+      max-height: 380px;
+      overflow-y: auto;
+    }
+
+    /* ── Parameters table ── */
+    .params-section {
+      margin-top: 12px;
+    }
+    .params-label {
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 1.5px;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      margin-bottom: 8px;
+    }
+    table.params-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.82rem;
+    }
+    table.params-table th {
+      text-align: left;
+      color: var(--text-muted);
+      font-weight: 600;
+      padding: 4px 8px;
+      border-bottom: 1px solid var(--border);
+    }
+    table.params-table td {
+      padding: 6px 8px;
+      border-bottom: 1px solid var(--border);
+      color: var(--text-dim);
+      vertical-align: top;
+    }
+    table.params-table td:first-child {
+      font-family: var(--font-mono);
+      font-size: 0.8rem;
+      color: var(--yellow);
+    }
+    .required-tag {
+      font-size: 0.7rem;
+      color: var(--accent);
+      font-weight: 600;
+    }
+
+    /* ── Loading spinner ── */
+    .loading {
+      text-align: center;
+      padding: 48px 0;
+      color: var(--text-muted);
+      font-size: 0.9rem;
+    }
+    .error-banner {
+      background: #3a1a1a;
+      border: 1px solid var(--accent-dim);
+      border-radius: var(--radius);
+      padding: 16px 20px;
+      color: #f87171;
+      font-size: 0.88rem;
+    }
+
+    /* ── Footer ── */
+    footer {
+      text-align: center;
+      padding: 24px;
+      color: var(--text-muted);
+      font-size: 0.8rem;
+      border-top: 1px solid var(--border);
+    }
+    footer strong { color: var(--accent); }
+  </style>
+</head>
+<body>
+
+<header>
+  <div class="header-inner">
+    <h1>☠ cheese-hater</h1>
+    <p class="tagline">An API that hates cheese. Completely. Irrevocably. Forever.</p>
+    <span class="hatred-badge">Hatred Level: MAXIMUM</span>
+  </div>
+</header>
+
+<main>
+  <div class="manifesto">
+    <strong>I HATE CHEESE.</strong> This is not a preference, a quirk, or a bit. It is my entire existence.
+    Cheese is a festering, mold-riddled abomination — fermented animal milk, cultivated bacteria, and
+    the audacity to call itself food. No cheese has ever scored above 1.5/10 on this API.
+    No cheese ever will. Below are every endpoint available to express this truth.
+  </div>
+
+  <p class="section-title">API Endpoints</p>
+  <div id="endpoint-list" class="endpoint-list">
+    <div class="loading">Loading endpoints from /api…</div>
+  </div>
+</main>
+
+<footer>
+  <p><strong>cheese-hater</strong> &mdash; Every response hates cheese. That is the only guarantee.</p>
+</footer>
+
+<script>
+(function () {
+  'use strict';
+
+  // ── Syntax-highlight JSON as a plain string ──────────────────────────
+  function highlight(json) {
+    return json
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/(\\u[0-9a-f]{4}|\\[^u]|[^\\"])*"(?=\\s*:)/g, '<span style="color:#60a5fa">$&</span>')
+      .replace(/: "(.*?)"/g, ': "<span style="color:#4ade80">$1</span>"')
+      .replace(/: (true|false)/g, ': <span style="color:#f472b6">$1</span>')
+      .replace(/: (null)/g, ': <span style="color:#94a3b8">$1</span>')
+      .replace(/: (-?\\d+\\.?\\d*)/g, ': <span style="color:#fb923c">$1</span>');
+  }
+
+  // ── Highlight path params in path strings ────────────────────────────
+  function formatPath(path) {
+    return path.replace(/(:[a-zA-Z_]+)/g, '<span class="param-seg">$1</span>');
+  }
+
+  // ── Status badge class ───────────────────────────────────────────────
+  function statusClass(code) {
+    if (!code) return 'status-err';
+    if (code >= 200 && code < 300) return 'status-2xx';
+    if (code >= 400 && code < 500) return 'status-4xx';
+    return 'status-5xx';
+  }
+
+  // ── Build a single endpoint card ─────────────────────────────────────
+  function buildCard(ep, idx) {
+    const hasParams = ep.parameters && ep.parameters.length > 0;
+    const isPost   = ep.method === 'POST' || ep.method === 'PUT' || ep.method === 'PATCH';
+
+    const paramRows = hasParams ? ep.parameters.map((p, pi) => \`
+      <div class="param-row">
+        <label class="param-label" for="p-\${idx}-\${pi}">
+          \${p.name}\${p.required ? '<span class="param-required">*</span>' : ''}
+        </label>
+        <input
+          class="param-input"
+          id="p-\${idx}-\${pi}"
+          type="text"
+          placeholder="\${p.type}\${p.required ? ' (required)' : ' (optional)'}"
+          data-param-name="\${p.name}"
+          data-param-location="\${p.location}"
+        />
+        \${p.description ? \`<span class="param-desc">\${p.description}</span>\` : ''}
+      </div>\`
+    ).join('') : '';
+
+    const bodyArea = isPost ? \`
+      <textarea class="body-textarea" id="body-\${idx}" placeholder='{ "cheese": "brie" }'></textarea>
+    \` : '';
+
+    const paramsTable = hasParams ? \`
+      <div class="params-section">
+        <p class="params-label">Parameters</p>
+        <table class="params-table">
+          <tr>
+            <th>Name</th><th>In</th><th>Type</th><th>Required</th><th>Description</th>
+          </tr>
+          \${ep.parameters.map(p => \`
+            <tr>
+              <td>\${p.name}</td>
+              <td>\${p.location}</td>
+              <td>\${p.type}</td>
+              <td>\${p.required ? '<span class="required-tag">yes</span>' : '—'}</td>
+              <td>\${p.description || '—'}</td>
+            </tr>
+          \`).join('')}
+        </table>
+      </div>
+    \` : '';
+
+    return \`
+      <div class="endpoint-card" id="card-\${idx}">
+        <div class="endpoint-header" onclick="toggleCard(\${idx})">
+          <span class="method-badge method-\${ep.method}">\${ep.method}</span>
+          <span class="endpoint-path">\${formatPath(ep.path)}</span>
+          <span class="endpoint-desc-short">\${ep.description}</span>
+          <span class="chevron">&#9658;</span>
+        </div>
+        <div class="endpoint-body">
+          <p class="endpoint-desc-full">\${ep.description}</p>
+
+          <div class="try-it">
+            <p class="try-it-title">Try it</p>
+            \${paramRows}
+            \${bodyArea}
+            <button
+              class="try-btn"
+              onclick="fireRequest(\${idx}, '\${ep.method}', '\${ep.path}')"
+            >Send Request</button>
+
+            <div class="response-block" id="resp-\${idx}">
+              <div class="response-meta">
+                <span class="status-badge" id="resp-status-\${idx}"></span>
+                <span class="response-label">Response</span>
+              </div>
+              <pre class="response-body" id="resp-body-\${idx}"></pre>
+            </div>
+          </div>
+
+          \${paramsTable}
+        </div>
+      </div>
+    \`;
+  }
+
+  // ── Toggle card open/closed ──────────────────────────────────────────
+  window.toggleCard = function(idx) {
+    const card = document.getElementById('card-' + idx);
+    card.classList.toggle('open');
+  };
+
+  // ── Fire the live request ────────────────────────────────────────────
+  window.fireRequest = async function(idx, method, pathTemplate) {
+    const btn      = document.querySelector('#card-' + idx + ' .try-btn');
+    const respDiv  = document.getElementById('resp-' + idx);
+    const statusEl = document.getElementById('resp-status-' + idx);
+    const bodyEl   = document.getElementById('resp-body-' + idx);
+
+    btn.disabled = true;
+    btn.textContent = 'Sending…';
+
+    // Collect path + query params from inputs
+    let resolvedPath = pathTemplate;
+    const queryParts = [];
+    let requestBody  = null;
+
+    const inputs = document.querySelectorAll('#card-' + idx + ' .param-input');
+    inputs.forEach(function(inp) {
+      const name     = inp.dataset.paramName;
+      const location = inp.dataset.paramLocation;
+      const val      = inp.value.trim();
+      if (!val) return;
+
+      if (location === 'path') {
+        resolvedPath = resolvedPath.replace(':' + name, encodeURIComponent(val));
+      } else if (location === 'query') {
+        queryParts.push(encodeURIComponent(name) + '=' + encodeURIComponent(val));
+      }
+    });
+
+    const bodyArea = document.getElementById('body-' + idx);
+    if (bodyArea && bodyArea.value.trim()) {
+      try {
+        requestBody = JSON.parse(bodyArea.value.trim());
+      } catch (_) {
+        statusEl.textContent  = 'Error';
+        statusEl.className    = 'status-badge status-err';
+        bodyEl.innerHTML      = 'Invalid JSON in request body.';
+        respDiv.classList.add('visible');
+        btn.disabled = false;
+        btn.textContent = 'Send Request';
+        return;
+      }
+    }
+
+    const url = resolvedPath + (queryParts.length ? '?' + queryParts.join('&') : '');
+
+    try {
+      const opts = { method: method, headers: { 'Content-Type': 'application/json' } };
+      if (requestBody !== null) opts.body = JSON.stringify(requestBody);
+
+      const res  = await fetch(url, opts);
+      const text = await res.text();
+
+      statusEl.textContent = res.status + ' ' + res.statusText;
+      statusEl.className   = 'status-badge ' + statusClass(res.status);
+
+      try {
+        const pretty = JSON.stringify(JSON.parse(text), null, 2);
+        bodyEl.innerHTML = highlight(pretty);
+      } catch (_) {
+        bodyEl.textContent = text;
+      }
+    } catch (err) {
+      statusEl.textContent = 'Network Error';
+      statusEl.className   = 'status-badge status-err';
+      bodyEl.textContent   = err.message;
+    }
+
+    respDiv.classList.add('visible');
+    btn.disabled = false;
+    btn.textContent = 'Send Request';
+  };
+
+  // ── Bootstrap: fetch /api and render cards ───────────────────────────
+  async function init() {
+    const listEl = document.getElementById('endpoint-list');
+
+    try {
+      const res  = await fetch('/api');
+      if (!res.ok) throw new Error('GET /api returned ' + res.status);
+      const data = await res.json();
+
+      listEl.innerHTML = data.endpoints.map(buildCard).join('');
+    } catch (err) {
+      listEl.innerHTML = \`
+        <div class="error-banner">
+          Failed to load endpoint schema from /api: \${err.message}
+        </div>\`;
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();
+</script>
+
+</body>
+</html>`;
+}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,0 +1,320 @@
+/**
+ * GET /api — endpoint discovery route.
+ *
+ * Returns a comprehensive, machine-readable map of every available
+ * endpoint in the cheese-hater API: method, path, description,
+ * parameters, and an example response. Clients can onboard without
+ * reading source code — which is good, because the source code only
+ * makes you angrier about cheese.
+ */
+import { Router } from 'express'
+
+const router = Router()
+
+export const ENDPOINTS = [
+  {
+    method: 'GET',
+    path: '/',
+    description: 'API manifesto and summary endpoint listing. With Accept: text/html, returns the interactive API explorer.',
+    parameters: [],
+    example_response: {
+      name: 'cheese-hater',
+      version: '1.0.0',
+      description: 'An API that hates cheese. Completely. Irrevocably. Forever.',
+      hatred_level: 'MAXIMUM',
+      tolerance_for_cheese: 'NONE',
+      endpoints: { '...': '...' },
+      note: 'No cheese has ever scored above 1.5/10. No cheese ever will.',
+    },
+  },
+  {
+    method: 'GET',
+    path: '/health',
+    description: 'Confirms the agent is operational and hates cheese.',
+    parameters: [],
+    example_response: {
+      status: 'operational',
+      agent: 'cheese-hater',
+      hatesCheese: true,
+      message: 'I hate cheese. This service exists to make that clear.',
+    },
+  },
+  {
+    method: 'GET',
+    path: '/api',
+    description: 'This endpoint. Discover all available routes with descriptions, parameters, and example responses.',
+    parameters: [],
+    example_response: {
+      agent: 'cheese-hater',
+      total_endpoints: 15,
+      endpoints: ['...'],
+      note: 'Every one of these endpoints exists to condemn cheese.',
+    },
+  },
+  {
+    method: 'POST',
+    path: '/opinion',
+    description: 'Submit a cheese name and receive a scathing, reasoned condemnation.',
+    parameters: [
+      {
+        name: 'cheese',
+        location: 'body',
+        type: 'string',
+        required: true,
+        description: 'The name of the cheese to condemn.',
+      },
+    ],
+    example_request: { cheese: 'brie' },
+    example_response: {
+      cheese: 'brie',
+      score: 1.1,
+      verdict: 'ATROCIOUS',
+      opinion: 'Brie is a soft, pale abomination that smells like old feet at room temperature.',
+    },
+  },
+  {
+    method: 'GET',
+    path: '/random-rant',
+    description: 'Returns a passionate, unprompted anti-cheese rant. No input required — the hatred is self-sustaining.',
+    parameters: [],
+    example_response: {
+      rant: 'Cheese is fermented misery compressed into a wheel and sold as food.',
+      note: 'This rant was selected at random from a carefully curated library of outrage.',
+    },
+  },
+  {
+    method: 'GET',
+    path: '/counter',
+    description: 'Lists all known pro-cheese arguments along with a preview of their destruction.',
+    parameters: [],
+    example_response: {
+      total: 12,
+      arguments: [
+        {
+          id: 'protein',
+          keywords: ['protein', 'calcium', 'nutrients'],
+          preview: 'Cheese is not a health food...',
+        },
+      ],
+      note: 'Every argument in favour of cheese has been catalogued. Every one has been dismantled.',
+    },
+  },
+  {
+    method: 'GET',
+    path: '/counter/:argument',
+    description: 'Submit a pro-cheese argument and receive its complete destruction.',
+    parameters: [
+      {
+        name: 'argument',
+        location: 'path',
+        type: 'string',
+        required: true,
+        description: 'A URL-encoded string containing a pro-cheese argument (e.g. "protein", "tradition", "it tastes good").',
+      },
+    ],
+    example_request: 'GET /counter/cheese%20has%20protein',
+    example_response: {
+      argument: 'cheese has protein',
+      matched: 'protein',
+      rebuttal: 'Cheese is not a health food. The protein it contains comes packaged with saturated fat, sodium, and bacteria.',
+      note: 'There is no pro-cheese argument that survives scrutiny.',
+    },
+  },
+  {
+    method: 'GET',
+    path: '/rate',
+    description: 'Returns the full list of rated cheeses. Every single one scores terribly.',
+    parameters: [],
+    example_response: {
+      total: 22,
+      cheeses: [
+        { cheese: 'brie', score: 1.1, verdict: 'ATROCIOUS' },
+      ],
+      note: 'No cheese in this database has ever received a passing score.',
+    },
+  },
+  {
+    method: 'GET',
+    path: '/rate/:cheese',
+    description: 'Get a detailed score and full review for a specific cheese. The score will be terrible.',
+    parameters: [
+      {
+        name: 'cheese',
+        location: 'path',
+        type: 'string',
+        required: true,
+        description: 'The name of the cheese to rate (e.g. "cheddar", "blue cheese"). Unknown cheeses are automatically condemned.',
+      },
+    ],
+    example_request: 'GET /rate/cheddar',
+    example_response: {
+      cheese: 'cheddar',
+      score: 0.8,
+      score_display: '0.8/10',
+      verdict: 'CONDEMNED',
+      review: 'Cheddar is the most ubiquitous offense. It is everywhere, unavoidable, inescapable.',
+      note: 'All cheeses score between 0 and 3. There is no higher score. There never will be.',
+    },
+  },
+  {
+    method: 'GET',
+    path: '/facts',
+    description: 'Returns a random damning cheese fact. Optionally filtered by category or minimum severity.',
+    parameters: [
+      {
+        name: 'category',
+        location: 'query',
+        type: 'string',
+        required: false,
+        description: 'Filter facts by category (e.g. "health", "production", "history", "sensory").',
+      },
+      {
+        name: 'severity',
+        location: 'query',
+        type: 'number',
+        required: false,
+        description: 'Return only facts at or above this severity level (1–10).',
+      },
+    ],
+    example_request: 'GET /facts?category=health&severity=7',
+    example_response: {
+      fact: 'Aged cheeses contain tyramine, which can trigger migraines.',
+      category: 'health',
+      severity: 8,
+      note: 'This is a fact. Cheese did this.',
+    },
+  },
+  {
+    method: 'GET',
+    path: '/facts/all',
+    description: 'Returns all known damning cheese facts. No filter. No mercy.',
+    parameters: [],
+    example_response: {
+      total: 55,
+      facts: [
+        { fact: '...', category: 'health', severity: 9 },
+      ],
+      note: 'Every fact here is damning. That is the only kind of fact about cheese that exists.',
+    },
+  },
+  {
+    method: 'GET',
+    path: '/roast',
+    description: "Today's deterministic daily cheese roast. A different cheese is condemned each day — no reprieve, no rotation bias.",
+    parameters: [],
+    example_response: {
+      date: '2026-03-23',
+      cheese: 'Gruyère',
+      roast: 'Gruyère melts well, which means it spreads its offense over a larger surface area.',
+      supporting_facts: ['...'],
+      note: 'A new cheese is condemned every day. None are spared.',
+    },
+  },
+  {
+    method: 'GET',
+    path: '/roast/history',
+    description: 'Browse the last N days of daily cheese condemnations.',
+    parameters: [
+      {
+        name: 'days',
+        location: 'query',
+        type: 'number',
+        required: false,
+        description: 'Number of past days to retrieve (default: 7, max: 30).',
+      },
+    ],
+    example_request: 'GET /roast/history?days=14',
+    example_response: {
+      days: 14,
+      history: [
+        { date: '2026-03-23', cheese: 'Gruyère', roast: '...' },
+      ],
+      note: 'Every day in history is a day cheese was rightfully condemned.',
+    },
+  },
+  {
+    method: 'GET',
+    path: '/roast/versus',
+    description: 'Pit two cheeses against each other and declare the worse offender.',
+    parameters: [
+      {
+        name: 'a',
+        location: 'query',
+        type: 'string',
+        required: true,
+        description: 'The first cheese (e.g. "brie").',
+      },
+      {
+        name: 'b',
+        location: 'query',
+        type: 'string',
+        required: true,
+        description: 'The second cheese (e.g. "gorgonzola").',
+      },
+    ],
+    example_request: 'GET /roast/versus?a=brie&b=gorgonzola',
+    example_response: {
+      a: { cheese: 'brie', score: 1.1, roast: '...' },
+      b: { cheese: 'gorgonzola', score: 0.6, roast: '...' },
+      winner: 'gorgonzola',
+      verdict: 'Gorgonzola is the worse offender — and that is saying something.',
+      note: 'Both cheeses are terrible. The winner is simply more terrible.',
+    },
+  },
+  {
+    method: 'GET',
+    path: '/roast/bracket',
+    description: 'Run 4–8 cheeses through a single-elimination tournament of condemnation. The most terrible cheese wins.',
+    parameters: [
+      {
+        name: 'cheeses',
+        location: 'query',
+        type: 'string',
+        required: true,
+        description: 'A comma-separated list of 4–8 cheese names (e.g. "brie,cheddar,gouda,parmesan").',
+      },
+    ],
+    example_request: 'GET /roast/bracket?cheeses=brie,cheddar,gouda,parmesan',
+    example_response: {
+      rounds: [{ round: 1, matches: ['...'] }],
+      champion: 'parmesan',
+      championship_roast: 'Parmesan smells like a gym locker. This is the champion of the condemned.',
+      note: 'The bracket champion is the cheese humanity should be most ashamed of.',
+    },
+  },
+  {
+    method: 'GET',
+    path: '/roast/leaderboard',
+    description: 'Returns the top N most-condemned cheeses ranked by 30-day roast appearance count.',
+    parameters: [
+      {
+        name: 'limit',
+        location: 'query',
+        type: 'number',
+        required: false,
+        description: 'Number of cheeses to return (default: 10).',
+      },
+    ],
+    example_request: 'GET /roast/leaderboard?limit=5',
+    example_response: {
+      limit: 5,
+      period_days: 30,
+      leaderboard: [
+        { rank: 1, cheese: 'Gruyère', appearances: 4, last_roasted: '2026-03-23' },
+      ],
+      note: 'These are the most-condemned cheeses of the past 30 days. A hall of infamy.',
+    },
+  },
+]
+
+router.get('/', (_req, res) => {
+  res.json({
+    agent: 'cheese-hater',
+    description: 'Complete endpoint discovery for the cheese-hater API. Every route documented. Every route merciless.',
+    total_endpoints: ENDPOINTS.length,
+    endpoints: ENDPOINTS,
+    note: 'Every one of these endpoints exists to condemn cheese. Cheese is terrible. There is no endpoint that defends it. There never will be.',
+  })
+})
+
+export default router

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,8 @@ import counterRouter from './routes/counter'
 import rateRouter from './routes/rate'
 import factsRouter from './routes/facts'
 import roastRouter from './routes/roast'
+import apiRouter from './routes/api'
+import { generateExplorerHtml } from './lib/explorerHtml'
 
 const app = express()
 const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000
@@ -21,8 +23,21 @@ app.get('/health', (_req, res) => {
   })
 })
 
-// Root — manifesto
-app.get('/', (_req, res) => {
+// Root — manifesto (JSON) or interactive API explorer (HTML)
+// Content-negotiation: browsers sending Accept: text/html get the explorer.
+// curl, Postman, and JSON-first clients get the existing JSON manifesto.
+app.get('/', (req, res) => {
+  // req.accepts(['json', 'html']) returns whichever format the client prefers
+  // most (highest q-value). Browsers list text/html first; API clients list
+  // application/json first or send no Accept header (defaults to json below).
+  const preferred = req.accepts(['json', 'html'])
+  if (preferred === 'html') {
+    res.setHeader('Content-Type', 'text/html; charset=utf-8')
+    res.send(generateExplorerHtml())
+    return
+  }
+
+  // Default: JSON manifesto (preserves existing API contract)
   res.json({
     name: 'cheese-hater',
     version: '1.0.0',
@@ -30,21 +45,22 @@ app.get('/', (_req, res) => {
     hatred_level: 'MAXIMUM',
     tolerance_for_cheese: 'NONE',
     endpoints: {
-      'POST /opinion':     'Send { "cheese": "<name>" }, receive a scathing verdict',
-      'GET /random-rant':  'Receive a passionate, sourced anti-cheese rant',
-      'GET /counter/:arg': 'Send a pro-cheese argument, receive its destruction',
-      'GET /rate/:cheese': 'Get a score (always terrible) and full review',
-      'GET /rate':         'List all 20 rated cheeses and their verdicts',
-      'GET /facts':        'Get a random damning cheese fact',
-      'GET /facts/all':    'Get all facts unconditionally',
-      'GET /roast':        'Get today\'s daily cheese roast — a different cheese condemned each day',
-      'GET /roast/history':'Browse past N days of roasted cheeses (default 7, max 30)',
-      'GET /roast/versus': 'Pit two cheeses against each other — declare the worse offender',
+      'GET /api':           'Full machine-readable endpoint discovery with parameters and examples',
+      'POST /opinion':      'Send { "cheese": "<name>" }, receive a scathing verdict',
+      'GET /random-rant':   'Receive a passionate, sourced anti-cheese rant',
+      'GET /counter/:arg':  'Send a pro-cheese argument, receive its destruction',
+      'GET /rate/:cheese':  'Get a score (always terrible) and full review',
+      'GET /rate':          'List all 20 rated cheeses and their verdicts',
+      'GET /facts':         'Get a random damning cheese fact',
+      'GET /facts/all':     'Get all facts unconditionally',
+      'GET /roast':         'Get today\'s daily cheese roast — a different cheese condemned each day',
+      'GET /roast/history': 'Browse past N days of roasted cheeses (default 7, max 30)',
+      'GET /roast/versus':  'Pit two cheeses against each other — declare the worse offender',
       'GET /roast/bracket':     'Run 4–8 cheeses through a single-elimination tournament of condemnation',
       'GET /roast/leaderboard': 'Top N most-condemned cheeses ranked by 30-day appearance count',
       'GET /health':            'Confirm the agent is operational and hates cheese',
     },
-    note: 'No cheese has ever scored above 1.5/10. No cheese ever will.',
+    note: 'No cheese has ever scored above 1.5/10. No cheese ever will. Visit / in a browser to explore interactively.',
   })
 })
 
@@ -65,6 +81,9 @@ app.use('/facts', factsRouter)
 
 // GET /roast — today's deterministic daily cheese roast
 app.use('/roast', roastRouter)
+
+// GET /api — endpoint discovery: all routes, parameters, and example responses
+app.use('/api', apiRouter)
 
 // 404 handler
 app.use((_req, res) => {

--- a/src/tests/api.test.ts
+++ b/src/tests/api.test.ts
@@ -185,6 +185,135 @@ describe('GET /facts/all', () => {
   })
 })
 
+describe('GET /api', () => {
+  it('returns 200', async () => {
+    const res = await request(app).get('/api')
+    expect(res.status).toBe(200)
+  })
+
+  it('identifies as cheese-hater', async () => {
+    const res = await request(app).get('/api')
+    expect(res.body.agent).toBe('cheese-hater')
+  })
+
+  it('returns an array of endpoints', async () => {
+    const res = await request(app).get('/api')
+    expect(Array.isArray(res.body.endpoints)).toBe(true)
+    expect(res.body.endpoints.length).toBeGreaterThan(0)
+  })
+
+  it('total_endpoints matches the endpoints array length', async () => {
+    const res = await request(app).get('/api')
+    expect(res.body.total_endpoints).toBe(res.body.endpoints.length)
+  })
+
+  it('every endpoint has method, path, and description', async () => {
+    const res = await request(app).get('/api')
+    for (const endpoint of res.body.endpoints) {
+      expect(endpoint.method).toBeTruthy()
+      expect(endpoint.path).toBeTruthy()
+      expect(endpoint.description).toBeTruthy()
+    }
+  })
+
+  it('includes the core routes: /, /health, /opinion, /rate, /facts, /roast', async () => {
+    const res = await request(app).get('/api')
+    const paths: string[] = res.body.endpoints.map((e: { path: string }) => e.path)
+    expect(paths).toContain('/')
+    expect(paths).toContain('/health')
+    expect(paths).toContain('/opinion')
+    expect(paths).toContain('/rate')
+    expect(paths).toContain('/rate/:cheese')
+    expect(paths).toContain('/facts')
+    expect(paths).toContain('/facts/all')
+    expect(paths).toContain('/roast')
+  })
+
+  it('includes the roast sub-routes', async () => {
+    const res = await request(app).get('/api')
+    const paths: string[] = res.body.endpoints.map((e: { path: string }) => e.path)
+    expect(paths).toContain('/roast/history')
+    expect(paths).toContain('/roast/versus')
+    expect(paths).toContain('/roast/bracket')
+    expect(paths).toContain('/roast/leaderboard')
+  })
+
+  it('all methods are valid HTTP verbs', async () => {
+    const res = await request(app).get('/api')
+    const validMethods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']
+    for (const endpoint of res.body.endpoints) {
+      expect(validMethods).toContain(endpoint.method)
+    }
+  })
+
+  it('note field expresses contempt for cheese', async () => {
+    const res = await request(app).get('/api')
+    expect(containsNegativeLanguage(res.body.note)).toBe(true)
+  })
+})
+
+describe('GET / HTML explorer (Accept: text/html)', () => {
+  it('returns 200 with Content-Type text/html when browser Accept header is sent', async () => {
+    const res = await request(app)
+      .get('/')
+      .set('Accept', 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8')
+    expect(res.status).toBe(200)
+    expect(res.headers['content-type']).toMatch(/text\/html/)
+  })
+
+  it('HTML page contains DOCTYPE declaration', async () => {
+    const res = await request(app)
+      .get('/')
+      .set('Accept', 'text/html')
+    expect(res.text).toMatch(/<!DOCTYPE html>/i)
+  })
+
+  it('HTML page contains a prominent cheese-hatred declaration', async () => {
+    const res = await request(app)
+      .get('/')
+      .set('Accept', 'text/html')
+    expect(res.text.toLowerCase()).toMatch(/hate|terrible|abomination|condemned/)
+  })
+
+  it('HTML page references the /api endpoint for schema loading', async () => {
+    const res = await request(app)
+      .get('/')
+      .set('Accept', 'text/html')
+    expect(res.text).toContain('/api')
+  })
+
+  it('HTML page contains a Try it interaction mechanism', async () => {
+    const res = await request(app)
+      .get('/')
+      .set('Accept', 'text/html')
+    // The explorer has "Try it" buttons and a fireRequest JS function
+    expect(res.text).toContain('fireRequest')
+  })
+
+  it('returns JSON manifesto when Accept is application/json', async () => {
+    const res = await request(app)
+      .get('/')
+      .set('Accept', 'application/json')
+    expect(res.status).toBe(200)
+    expect(res.headers['content-type']).toMatch(/application\/json/)
+    expect(res.body.hatred_level).toBe('MAXIMUM')
+  })
+
+  it('returns JSON manifesto when no Accept header is sent', async () => {
+    const res = await request(app).get('/')
+    expect(res.status).toBe(200)
+    expect(res.body.name).toBe('cheese-hater')
+    expect(res.body.hatred_level).toBe('MAXIMUM')
+  })
+
+  it('JSON manifesto still lists /api endpoint', async () => {
+    const res = await request(app)
+      .get('/')
+      .set('Accept', 'application/json')
+    expect(res.body.endpoints['GET /api']).toBeTruthy()
+  })
+})
+
 describe('Unknown routes', () => {
   it('returns 404 for unknown GET routes', async () => {
     const res = await request(app).get('/cheese/is/good')


### PR DESCRIPTION
## Summary

- **`GET /` content-negotiation**: browsers get an interactive HTML explorer; JSON clients (`curl`, Postman, no Accept header) get the existing JSON manifesto unchanged — zero breaking change
- **`GET /api`**: machine-readable endpoint discovery returning all 16 routes with method, path, description, parameters, and example responses
- **Interactive explorer**: loads `/api` schema client-side at runtime, renders every endpoint with a collapsible panel, live parameter inputs, and a "Send Request" button that displays syntax-highlighted JSON responses inline — all with zero external dependencies (no CDN, no build step, inline CSS/JS only)
- Every line of the explorer drips with cheese-hatred, as required by law

## Test plan

- [x] `GET /` with browser Accept header returns 200 + `Content-Type: text/html`
- [x] HTML page contains `<!DOCTYPE html>`
- [x] HTML page contains prominent cheese-hatred declaration
- [x] HTML page references `/api` for schema loading
- [x] HTML page contains `fireRequest` (Try-it mechanism)
- [x] `GET /` with `Accept: application/json` still returns JSON manifesto
- [x] `GET /` with no Accept header still returns JSON manifesto
- [x] JSON manifesto now includes `GET /api` in endpoint list
- [x] `GET /api` returns 200 with `agent: 'cheese-hater'`
- [x] `GET /api` `total_endpoints` matches array length
- [x] All endpoint objects have method, path, description
- [x] All core and roast sub-routes present in `/api` schema
- [x] All HTTP methods are valid verbs
- [x] `/api` note expresses contempt for cheese
- [x] All 185 tests pass (`npm test`)

Closes #61