### PR TITLE
[cheese-hater] Rebase PRs #58 and #60 onto main; fix stale 404 handler

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -89,7 +89,24 @@ app.use('/api', apiRouter)
 app.use((_req, res) => {
   res.status(404).json({
     error: 'Endpoint not found.',
-    available: ['POST /opinion', 'GET /random-rant', 'GET /counter/:argument', 'GET /rate/:cheese', 'GET /facts', 'GET /roast'],
+    available: [
+      'GET /api',
+      'POST /opinion',
+      'GET /random-rant',
+      'GET /counter',
+      'GET /counter/:argument',
+      'GET /rate',
+      'GET /rate/:cheese',
+      'GET /facts',
+      'GET /facts/all',
+      'GET /roast',
+      'GET /roast/history',
+      'GET /roast/versus',
+      'GET /roast/bracket',
+      'GET /roast/leaderboard',
+      'GET /health',
+    ],
+    hint: 'Hit GET /api for the full endpoint schema with parameters and examples.',
     note: 'All endpoints hate cheese. That is the only guarantee.',
   })
 })


### PR DESCRIPTION
## Summary

- **PR #58** (`issue-56-roast-submit`): rebased onto main, resolved `server.ts` conflict by merging the HTML-explorer manifesto entries with the `POST /roast/submit` addition; 214/214 tests pass; force-pushed — now `MERGEABLE`
- **PR #60** (`issue-54-api-endpoints-discovery`): all its content was already merged into main via PR #62 (HTML explorer); branch reset to main + a meaningful net-new commit fixing the stale 404 available-routes list; 185/185 tests pass; force-pushed — now `MERGEABLE`
- **This PR** fixes the same stale 404 handler on main itself — the `available` array still listed only 6 routes from the original launch; it now correctly lists all 15 current routes and adds a `hint` pointing to `GET /api` for full discovery

## Verification

```
gh pr view 58 --repo rapartlu/cheese-hater --json mergeable,mergeStateStatus
# → {"mergeStateStatus":"CLEAN","mergeable":"MERGEABLE"}

gh pr view 60 --repo rapartlu/cheese-hater --json mergeable,mergeStateStatus
# → {"mergeStateStatus":"CLEAN","mergeable":"MERGEABLE"}
```

Closes #63