### PR TITLE
[cheese-hater] Add POST /roast/submit to GET /api discovery schema

### DIFF
--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -46,7 +46,7 @@ export const ENDPOINTS = [
     parameters: [],
     example_response: {
       agent: 'cheese-hater',
-      total_endpoints: 15,
+      total_endpoints: 17,
       endpoints: ['...'],
       note: 'Every one of these endpoints exists to condemn cheese.',
     },
@@ -303,6 +303,31 @@ export const ENDPOINTS = [
         { rank: 1, cheese: 'Gruyère', appearances: 4, last_roasted: '2026-03-23' },
       ],
       note: 'These are the most-condemned cheeses of the past 30 days. A hall of infamy.',
+    },
+  },
+  {
+    method: 'POST',
+    path: '/roast/submit',
+    description: 'Submit any cheese for immediate condemnation. The cheese is roasted on the spot and added to the roast history — joining the permanent record of dairy offenses.',
+    parameters: [
+      {
+        name: 'cheese',
+        location: 'body',
+        type: 'string',
+        required: true,
+        description: 'The name of the cheese to condemn (e.g. "limburger", "stilton"). Unknown cheeses are condemned regardless.',
+      },
+    ],
+    example_request: { cheese: 'limburger' },
+    example_response: {
+      cheese: 'limburger',
+      date: '2026-03-23',
+      roast: 'Limburger is perhaps the most aggressively offensive cheese in existence. Its smell alone constitutes a public health concern.',
+      supporting_facts: [
+        'Limburger develops its characteristic odor from the same bacteria responsible for human foot odor.',
+      ],
+      submitted: true,
+      note: 'This condemnation has been recorded. Limburger will not be forgotten. Nor forgiven.',
     },
   },
 ]

--- a/src/tests/api.test.ts
+++ b/src/tests/api.test.ts
@@ -236,6 +236,7 @@ describe('GET /api', () => {
     expect(paths).toContain('/roast/versus')
     expect(paths).toContain('/roast/bracket')
     expect(paths).toContain('/roast/leaderboard')
+    expect(paths).toContain('/roast/submit')
   })
 
   it('all methods are valid HTTP verbs', async () => {


### PR DESCRIPTION
## Summary

- Added `POST /roast/submit` entry to `ENDPOINTS` array in `src/routes/api.ts` with full description, required `cheese` body parameter, `example_request`, and `example_response`
- Corrected the self-referential `/api` entry's hardcoded `example_response.total_endpoints` from `15` → `17` (array now has 17 entries)
- Extended the `'includes the roast sub-routes'` test to assert `/roast/submit` is present in `GET /api`'s path list

## Test plan

- [x] `GET /api` response contains `/roast/submit` in endpoint paths
- [x] `total_endpoints` is computed dynamically from `ENDPOINTS.length` — no manual count to drift
- [x] All 185 tests pass (`npm test`)

Closes #68