### PR TITLE
[cheese-hater] Add GET /verdict/:cheese — structured per-cheese condemnation

### DIFF
--- a/src/data/cheese-verdicts.json
+++ b/src/data/cheese-verdicts.json
@@ -1,0 +1,124 @@
+{
+  "verdicts": [
+    {
+      "cheese": "brie",
+      "verdict": "GUILTY",
+      "severity": "high",
+      "worst_quality": "the rind is legally edible mold — and that is the selling point",
+      "smell_description": "wet gym towel left in a warm car for three days",
+      "texture_offense": "aggressively soft; collapses without apology onto everything it touches",
+      "found_at": "every party cheese board where it has been sitting at room temperature for two hours while guests pretend not to notice the smell",
+      "recommended_alternative": "literally anything else — a cracker, plain air, silence",
+      "closing_statement": "Brie is what happens when someone decided that eating mold should be aspirational. The sophistication is performed. The mold is real."
+    },
+    {
+      "cheese": "cheddar",
+      "verdict": "GUILTY",
+      "severity": "high",
+      "worst_quality": "its ubiquity — cheddar is everywhere, unavoidable, normalized into acceptability by sheer repetition",
+      "smell_description": "the inside of a refrigerator that has quietly given up",
+      "texture_offense": "rubbery when young; crumbly and aggressively sharp when aged — neither state is an improvement",
+      "found_at": "every grocery store checkout lane, every sad sandwich, every moment of culinary complacency in the developed world",
+      "recommended_alternative": "mustard, hummus, avocado, or the radical concept of a topping-free experience",
+      "closing_statement": "Cheddar is the default cheese — and defaults exist for convenience, not because they are good. Cheddar has never earned its position. It simply never left."
+    },
+    {
+      "cheese": "blue cheese",
+      "verdict": "GUILTY",
+      "severity": "extreme",
+      "worst_quality": "deliberately cultivated mold throughout the entire interior — this is the intended feature, not a defect",
+      "smell_description": "a damp basement that has been fermenting for several decades",
+      "texture_offense": "crumbles aggressively; the mold veins leave blue-grey stains on everything they contact",
+      "found_at": "wedge salads at steakhouses, where it is placed near food that does not deserve this proximity",
+      "recommended_alternative": "any dressing that does not contain intentional fungal colonies",
+      "closing_statement": "Blue cheese represents a decision point in culinary history — someone looked at a wheel of rotting dairy and said 'more of this.' That decision has not aged well. The cheese, unfortunately, has."
+    },
+    {
+      "cheese": "parmesan",
+      "verdict": "GUILTY",
+      "severity": "high",
+      "worst_quality": "the butyric acid content — the same chemical compound present in human vomit, present here as a selling point called 'sharpness'",
+      "smell_description": "a gym locker that has been sealed since 2009",
+      "texture_offense": "grated into a powder that disperses invisibly onto food, making contamination removal impossible",
+      "found_at": "shaved onto expensive pasta by servers who ask if you want 'a little more' as though more is a neutral option",
+      "recommended_alternative": "a squeeze of lemon, toasted breadcrumbs, or the restraint to leave the dish alone",
+      "closing_statement": "Parmesan is defended with the phrase 'it adds flavor.' Yes. The flavor of butyric acid — the molecule your body produces when it vomits. Restaurants present this as a finishing touch. The audacity compounds annually."
+    },
+    {
+      "cheese": "gouda",
+      "verdict": "GUILTY",
+      "severity": "moderate",
+      "worst_quality": "its deceptive approachability — gouda presents as mild and inoffensive, which is precisely how gateway cheeses operate",
+      "smell_description": "faintly dairy, almost reasonable — which is how it gets you",
+      "texture_offense": "smooth and yielding in a way that disguises what it fundamentally is: curdled, fermented animal milk",
+      "found_at": "charcuterie boards assembled by people who want to seem unpretentious while still serving cheese",
+      "recommended_alternative": "actual fruit on the charcuterie board — the components that were always the best part",
+      "closing_statement": "Gouda is the gateway cheese. It seems fine. It is not fine. Nothing about the process that created it is fine. Gouda is what happens when cheese puts on a reasonable face."
+    },
+    {
+      "cheese": "mozzarella",
+      "verdict": "GUILTY",
+      "severity": "high",
+      "worst_quality": "the stretch — mozzarella produces a rubbery, elastic pull that the food industry has successfully rebranded as a desirable quality called 'melt'",
+      "smell_description": "fresh mozzarella smells of slightly off milk; the pre-shredded variety smells of the cellulose wood pulp it is coated in to prevent clumping",
+      "texture_offense": "the squeak, the stretch, the rubber-like resistance — the texture of something that should not be in a human mouth",
+      "found_at": "on top of every pizza, where it has been normalized to the point that 'pizza without cheese' is treated as an incomplete sentence",
+      "recommended_alternative": "tomato sauce, vegetables, and the realization that pizza was already complete",
+      "closing_statement": "Mozzarella's greatest cultural achievement is making its presence on pizza feel mandatory. It is not mandatory. It is curdled dairy stretched into sheets and melted onto bread. The normalization is the offense."
+    },
+    {
+      "cheese": "gruyère",
+      "verdict": "GUILTY",
+      "severity": "high",
+      "worst_quality": "its melting properties — gruyère melts exceptionally well, which means it spreads its offense across a larger surface area than most cheeses can achieve",
+      "smell_description": "nutty and pungent in a way that confirms it has been fermenting in a Swiss cave for months",
+      "texture_offense": "dense and firm until heat is applied, at which point it becomes a thin film of dairy coating everything it touches",
+      "found_at": "fondue pots at communal dining experiences, where multiple people share a single vessel of molten cheese — a ritual of collective dairy suffering",
+      "recommended_alternative": "broth-based fondues, or simply eating the bread without the surrounding vehicle of communal cheese",
+      "closing_statement": "Gruyère's culinary legacy is fondue — the practice of melting cheese communally so that an entire table must participate in the experience simultaneously. This was marketed as intimacy. It is not intimacy. It is mandatory cheese."
+    },
+    {
+      "cheese": "cream cheese",
+      "verdict": "GUILTY",
+      "severity": "high",
+      "worst_quality": "its spreadability — cream cheese applies to surfaces uniformly and completely, ensuring total coverage and no avenue of escape for whatever it contacts",
+      "smell_description": "mild dairy with a faint tang that intensifies on inspection",
+      "texture_offense": "smooth and frictionless delivery system for dairy content; removes all barriers between cheese and whatever it is spread onto",
+      "found_at": "bagels (where it is called a spread, as though renaming it changes what it is), and cheesecake (where it impersonates dessert)",
+      "recommended_alternative": "butter for bagels; actual dessert for dessert",
+      "closing_statement": "Cream cheese is cheese that learned to hide. It calls itself a spread. It presents itself as dessert. It is neither. It is dairy, fermented, processed into a paste, and optimized for application to other foods so it can contaminate them completely."
+    },
+    {
+      "cheese": "cottage cheese",
+      "verdict": "GUILTY",
+      "severity": "extreme",
+      "worst_quality": "the curds — cottage cheese exists in discrete wet lumps suspended in liquid, a format that even dedicated cheese consumers struggle to defend aesthetically",
+      "smell_description": "aggressively dairy; the smell of fresh curdling with no aging to moderate it",
+      "texture_offense": "lumpy, wet, and inconsistent — each spoonful delivers a different ratio of curd to liquid, ensuring no two bites are the same offense",
+      "found_at": "1970s diet culture, where it was presented as a health food on the grounds that it contained protein — which does not make it good",
+      "recommended_alternative": "Greek yoghurt, which has already solved this problem without requiring the curd format",
+      "closing_statement": "Cottage cheese is what cheese looks like before anyone has tried to make it presentable. It skipped that step. It arrived at the table in its raw, lumpy, wet state and declared itself ready. It was not ready."
+    },
+    {
+      "cheese": "halloumi",
+      "verdict": "GUILTY",
+      "severity": "high",
+      "worst_quality": "the squeak — halloumi produces an audible noise against teeth during consumption, a sound the cheese makes to register its objection to being eaten",
+      "smell_description": "briny and dairy; the smell of something that has been preserved in salt water, which is exactly what has happened to it",
+      "texture_offense": "the squeak is the texture — a rubbery, resistant dental experience that produces noise as a byproduct",
+      "found_at": "barbecues, where its high melting point is cited as a virtue — as though the ability to be grilled without melting is a quality cheese should aspire to",
+      "recommended_alternative": "grilled vegetables, which also benefit from heat without requiring the auditory experience",
+      "closing_statement": "Halloumi squeaks when eaten. That sound is the cheese communicating its displeasure at being consumed. The appropriate response is to listen to it."
+    }
+  ],
+  "generic_verdict": {
+    "verdict": "GUILTY",
+    "severity": "high",
+    "worst_quality": "its fundamental nature — it is fermented, bacteria-cultivated, mold-adjacent curdled animal milk, and no amount of naming or aging changes that",
+    "smell_description": "dairy, fermented, and unmistakably the result of a process that most foods wisely avoid",
+    "texture_offense": "the texture is cheese texture — a category that should never have existed",
+    "found_at": "places where someone made a choice that could have gone differently",
+    "recommended_alternative": "literally anything that is not cheese — the category of alternatives is enormous and entirely viable",
+    "closing_statement": "This cheese is guilty of being cheese. All cheeses share this guilt. The specific variety only determines the specific nature of the offense."
+  }
+}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -330,6 +330,47 @@ export const ENDPOINTS = [
       note: 'This condemnation has been recorded. Limburger will not be forgotten. Nor forgiven.',
     },
   },
+  {
+    method: 'GET',
+    path: '/verdict',
+    description: 'List all cheeses with known structured verdicts — severity rating, smell, texture offense, and recommended alternative.',
+    parameters: [],
+    example_response: {
+      total: 10,
+      cheeses: [
+        { cheese: 'brie', verdict: 'GUILTY', severity: 'high' },
+        { cheese: 'cheddar', verdict: 'GUILTY', severity: 'high' },
+      ],
+      note: 'For a full structured condemnation, use GET /verdict/:cheese. Unknown cheeses receive a generic verdict — because no cheese is innocent.',
+    },
+  },
+  {
+    method: 'GET',
+    path: '/verdict/:cheese',
+    description: 'Get a structured, field-by-field condemnation of a named cheese: its worst quality, smell, texture offense, where you encounter it, a recommended alternative, and a closing statement. All cheeses are guilty. The verdict is never in doubt.',
+    parameters: [
+      {
+        name: 'cheese',
+        location: 'path',
+        type: 'string',
+        required: true,
+        description: 'The name of the cheese to condemn (e.g. "brie", "cheddar", "halloumi"). Unknown cheeses receive a generic but equally scathing verdict.',
+      },
+    ],
+    example_request: 'GET /verdict/brie',
+    example_response: {
+      cheese: 'brie',
+      verdict: 'GUILTY',
+      severity: 'high',
+      worst_quality: 'the rind is legally edible mold — and that is the selling point',
+      smell_description: 'wet gym towel left in a warm car for three days',
+      texture_offense: 'aggressively soft; collapses without apology onto everything it touches',
+      found_at: 'every party cheese board where it has been sitting at room temperature for two hours',
+      recommended_alternative: 'literally anything else — a cracker, plain air, silence',
+      closing_statement: 'Brie is what happens when someone decided that eating mold should be aspirational. The sophistication is performed. The mold is real.',
+      note: 'All cheeses are guilty. The verdict is never in doubt. Only the specifics vary.',
+    },
+  },
 ]
 
 router.get('/', (_req, res) => {

--- a/src/routes/verdict.ts
+++ b/src/routes/verdict.ts
@@ -1,0 +1,87 @@
+/**
+ * GET /verdict/:cheese — structured per-cheese condemnation.
+ *
+ * Unlike GET /rate/:cheese which returns a score and a review,
+ * /verdict returns a rich, structured breakdown of *why* a specific
+ * cheese is terrible: its worst quality, its smell, its texture offense,
+ * where you typically encounter it, and a closing statement.
+ *
+ * Every cheese is guilty. The verdict is always the same.
+ * The specifics are what make it useful.
+ */
+import { Router, Request, Response } from 'express'
+import verdictsData from '../data/cheese-verdicts.json'
+
+const router = Router()
+
+interface CheeseVerdict {
+  cheese?: string
+  verdict: string
+  severity: string
+  worst_quality: string
+  smell_description: string
+  texture_offense: string
+  found_at: string
+  recommended_alternative: string
+  closing_statement: string
+}
+
+interface VerdictsData {
+  verdicts: (CheeseVerdict & { cheese: string })[]
+  generic_verdict: CheeseVerdict
+}
+
+const data = verdictsData as VerdictsData
+const knownVerdicts = data.verdicts
+const genericVerdict = data.generic_verdict
+
+function getVerdict(name: string): CheeseVerdict & { cheese: string } {
+  const lower = name.toLowerCase().trim()
+
+  // Try exact match first, then partial (handles "blue" matching "blue cheese")
+  const match =
+    knownVerdicts.find(v => v.cheese === lower) ??
+    knownVerdicts.find(v => lower.includes(v.cheese) || v.cheese.includes(lower))
+
+  if (match) return match
+
+  // Unknown cheese: return generic verdict with the provided name
+  return {
+    cheese: name,
+    ...genericVerdict,
+  }
+}
+
+// GET /verdict/:cheese — structured condemnation for a named cheese
+router.get('/:cheese', (req: Request, res: Response) => {
+  const cheeseName = decodeURIComponent(req.params.cheese).trim()
+  const result = getVerdict(cheeseName)
+
+  res.json({
+    cheese: result.cheese,
+    verdict: result.verdict,
+    severity: result.severity,
+    worst_quality: result.worst_quality,
+    smell_description: result.smell_description,
+    texture_offense: result.texture_offense,
+    found_at: result.found_at,
+    recommended_alternative: result.recommended_alternative,
+    closing_statement: result.closing_statement,
+    note: 'All cheeses are guilty. The verdict is never in doubt. Only the specifics vary.',
+  })
+})
+
+// GET /verdict — list all cheeses with known structured verdicts
+router.get('/', (_req: Request, res: Response) => {
+  res.json({
+    total: knownVerdicts.length,
+    cheeses: knownVerdicts.map(v => ({
+      cheese: v.cheese,
+      verdict: v.verdict,
+      severity: v.severity,
+    })),
+    note: 'For a full structured condemnation, use GET /verdict/:cheese. Unknown cheeses receive a generic verdict — because no cheese is innocent.',
+  })
+})
+
+export default router

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import rateRouter from './routes/rate'
 import factsRouter from './routes/facts'
 import roastRouter from './routes/roast'
 import apiRouter from './routes/api'
+import verdictRouter from './routes/verdict'
 import { generateExplorerHtml } from './lib/explorerHtml'
 
 const app = express()
@@ -51,6 +52,8 @@ app.get('/', (req, res) => {
       'GET /counter/:arg':      'Send a pro-cheese argument, receive its destruction',
       'GET /rate/:cheese':      'Get a score (always terrible) and full review',
       'GET /rate':              'List all 20 rated cheeses and their verdicts',
+      'GET /verdict/:cheese':   'Get a structured condemnation: severity, smell, texture offense, closing statement',
+      'GET /verdict':           'List all cheeses with known structured verdicts',
       'GET /facts':             'Get a random damning cheese fact',
       'GET /facts/all':         'Get all facts unconditionally',
       'GET /roast':             'Get today\'s daily cheese roast — a different cheese condemned each day',
@@ -83,6 +86,9 @@ app.use('/facts', factsRouter)
 // GET /roast — today's deterministic daily cheese roast
 app.use('/roast', roastRouter)
 
+// GET /verdict/:cheese — structured per-cheese condemnation with severity rating
+app.use('/verdict', verdictRouter)
+
 // GET /api — endpoint discovery: all routes, parameters, and example responses
 app.use('/api', apiRouter)
 
@@ -98,6 +104,8 @@ app.use((_req, res) => {
       'GET /counter/:argument',
       'GET /rate',
       'GET /rate/:cheese',
+      'GET /verdict',
+      'GET /verdict/:cheese',
       'GET /facts',
       'GET /facts/all',
       'GET /roast',

--- a/src/tests/verdict.test.ts
+++ b/src/tests/verdict.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for GET /verdict and GET /verdict/:cheese.
+ *
+ * Every cheese is guilty. The verdict is never in doubt.
+ * These tests verify the specifics.
+ */
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import app from '../server'
+
+const REQUIRED_FIELDS = [
+  'cheese',
+  'verdict',
+  'severity',
+  'worst_quality',
+  'smell_description',
+  'texture_offense',
+  'found_at',
+  'recommended_alternative',
+  'closing_statement',
+  'note',
+] as const
+
+// The 10 cheeses documented in CLAUDE.md — each deserves targeted contempt
+const KNOWN_CHEESES = [
+  'brie',
+  'cheddar',
+  'blue cheese',
+  'parmesan',
+  'gouda',
+  'mozzarella',
+  'gruyère',
+  'cream cheese',
+  'cottage cheese',
+  'halloumi',
+]
+
+describe('GET /verdict', () => {
+  it('returns 200 with a list of cheeses', async () => {
+    const res = await request(app).get('/verdict')
+    expect(res.status).toBe(200)
+    expect(Array.isArray(res.body.cheeses)).toBe(true)
+  })
+
+  it('includes total count matching the cheeses array length', async () => {
+    const res = await request(app).get('/verdict')
+    expect(res.body.total).toBe(res.body.cheeses.length)
+  })
+
+  it('covers all 10 CLAUDE.md-documented cheeses', async () => {
+    const res = await request(app).get('/verdict')
+    const listed: string[] = res.body.cheeses.map((c: { cheese: string }) =>
+      c.cheese.toLowerCase(),
+    )
+    for (const cheese of KNOWN_CHEESES) {
+      expect(listed, `Expected "${cheese}" in /verdict list`).toContain(cheese)
+    }
+  })
+
+  it('every list entry has cheese, verdict, and severity', async () => {
+    const res = await request(app).get('/verdict')
+    for (const entry of res.body.cheeses) {
+      expect(entry).toHaveProperty('cheese')
+      expect(entry).toHaveProperty('verdict')
+      expect(entry).toHaveProperty('severity')
+    }
+  })
+
+  it('all verdicts in the list are GUILTY', async () => {
+    const res = await request(app).get('/verdict')
+    for (const entry of res.body.cheeses) {
+      expect(entry.verdict).toBe('GUILTY')
+    }
+  })
+})
+
+describe('GET /verdict/:cheese — known cheeses', () => {
+  for (const cheese of KNOWN_CHEESES) {
+    it(`condemns ${cheese} with all required fields`, async () => {
+      const res = await request(app).get(
+        `/verdict/${encodeURIComponent(cheese)}`,
+      )
+      expect(res.status).toBe(200)
+      for (const field of REQUIRED_FIELDS) {
+        expect(res.body, `Missing field "${field}" for ${cheese}`).toHaveProperty(field)
+        expect(typeof res.body[field]).toBe('string')
+        expect(res.body[field].length).toBeGreaterThan(0)
+      }
+    })
+
+    it(`${cheese} verdict is always GUILTY`, async () => {
+      const res = await request(app).get(
+        `/verdict/${encodeURIComponent(cheese)}`,
+      )
+      expect(res.body.verdict).toBe('GUILTY')
+    })
+
+    it(`${cheese} cheese field matches the requested name (case-normalised)`, async () => {
+      const res = await request(app).get(
+        `/verdict/${encodeURIComponent(cheese)}`,
+      )
+      expect(res.body.cheese.toLowerCase()).toBe(cheese.toLowerCase())
+    })
+  }
+})
+
+describe('GET /verdict/:cheese — unknown cheeses', () => {
+  it('returns 200 (not 404) for an unrecognised cheese', async () => {
+    const res = await request(app).get('/verdict/stilton')
+    expect(res.status).toBe(200)
+  })
+
+  it('unknown cheese echoes back the requested name', async () => {
+    const res = await request(app).get('/verdict/stilton')
+    expect(res.body.cheese).toBe('stilton')
+  })
+
+  it('unknown cheese is still GUILTY', async () => {
+    const res = await request(app).get('/verdict/mysterycheese')
+    expect(res.body.verdict).toBe('GUILTY')
+  })
+
+  it('unknown cheese has all required fields', async () => {
+    const res = await request(app).get('/verdict/weirdcheese')
+    for (const field of REQUIRED_FIELDS) {
+      expect(res.body, `Missing field "${field}" for unknown cheese`).toHaveProperty(field)
+    }
+  })
+
+  it('handles URL-encoded cheese names', async () => {
+    const res = await request(app).get('/verdict/cream%20cheese')
+    expect(res.status).toBe(200)
+    expect(res.body.verdict).toBe('GUILTY')
+  })
+
+  it('handles cheese names with spaces', async () => {
+    const res = await request(app).get('/verdict/blue%20cheese')
+    expect(res.status).toBe(200)
+    expect(res.body.cheese.toLowerCase()).toBe('blue cheese')
+  })
+})
+
+describe('GET /verdict/:cheese — partial matching', () => {
+  it('"blue" matches "blue cheese"', async () => {
+    const res = await request(app).get('/verdict/blue')
+    expect(res.status).toBe(200)
+    // Should either match blue cheese specifically or return generic — either way GUILTY
+    expect(res.body.verdict).toBe('GUILTY')
+  })
+})
+
+describe('GET /verdict severity levels', () => {
+  const VALID_SEVERITIES = ['moderate', 'high', 'extreme', 'catastrophic']
+
+  it('all known cheese verdicts have a recognised severity level', async () => {
+    const res = await request(app).get('/verdict')
+    for (const entry of res.body.cheeses) {
+      expect(
+        VALID_SEVERITIES,
+        `Unexpected severity "${entry.severity}" for ${entry.cheese}`,
+      ).toContain(entry.severity)
+    }
+  })
+
+  it('blue cheese severity is extreme (deliberately cultivated mold warrants escalation)', async () => {
+    const res = await request(app).get('/verdict/blue%20cheese')
+    expect(res.body.severity).toBe('extreme')
+  })
+
+  it('cottage cheese severity is extreme (the lumps demand it)', async () => {
+    const res = await request(app).get('/verdict/cottage%20cheese')
+    expect(res.body.severity).toBe('extreme')
+  })
+
+  it('gouda severity is moderate (gateway cheese, not yet peak offense)', async () => {
+    const res = await request(app).get('/verdict/gouda')
+    expect(res.body.severity).toBe('moderate')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `GET /verdict/:cheese` — a new endpoint returning a rich, field-by-field condemnation for any named cheese
- Adds `GET /verdict` — lists all 10 cheeses with known structured verdicts and their severity ratings
- Adds `src/data/cheese-verdicts.json` — targeted verdicts for all 10 CLAUDE.md-documented cheeses (brie, cheddar, blue cheese, parmesan, gouda, mozzarella, gruyère, cream cheese, cottage cheese, halloumi)
- Unknown cheeses return a generic but equally scathing verdict — no cheese is innocent

## Response shape

```json
{
  "cheese": "brie",
  "verdict": "GUILTY",
  "severity": "high",
  "worst_quality": "the rind is legally edible mold — and that is the selling point",
  "smell_description": "wet gym towel left in a warm car for three days",
  "texture_offense": "aggressively soft; collapses without apology onto everything it touches",
  "found_at": "every party cheese board where it has been sitting at room temperature for two hours",
  "recommended_alternative": "literally anything else — a cracker, plain air, silence",
  "closing_statement": "Brie is what happens when someone decided that eating mold should be aspirational. The sophistication is performed. The mold is real.",
  "note": "All cheeses are guilty. The verdict is never in doubt. Only the specifics vary."
}
```

## Why this is better than /rate

`/rate` gives a score. `/verdict` gives a *case*. Structured fields make this embeddable in UIs, CLI tools, and other integrations. Each cheese gets targeted contempt rather than generic disgust — which is both more satisfying and more honest to the mission.

## Schema drift

The schema-drift test from Issue #70 automatically validated that both new routes appear in `GET /api` — no manual schema sync required.

## Tests

- 265/265 passing
- 46 new assertions in `verdict.test.ts` covering: all 10 known cheeses × (fields present, GUILTY verdict, name echo), unknown cheese fallback, URL encoding, partial matching, severity levels

Closes #76