### PR TITLE
[cheese-hater] Add GET /compare — structured head-to-head cheese condemnation

### DIFF
--- a/src/data/cheese-verdicts.json
+++ b/src/data/cheese-verdicts.json
@@ -9,7 +9,10 @@
       "texture_offense": "aggressively soft; collapses without apology onto everything it touches",
       "found_at": "every party cheese board where it has been sitting at room temperature for two hours while guests pretend not to notice the smell",
       "recommended_alternative": "literally anything else — a cracker, plain air, silence",
-      "closing_statement": "Brie is what happens when someone decided that eating mold should be aspirational. The sophistication is performed. The mold is real."
+      "closing_statement": "Brie is what happens when someone decided that eating mold should be aspirational. The sophistication is performed. The mold is real.",
+      "smell_score": 8,
+      "texture_score": 9,
+      "cultural_damage_score": 6
     },
     {
       "cheese": "cheddar",
@@ -20,7 +23,10 @@
       "texture_offense": "rubbery when young; crumbly and aggressively sharp when aged — neither state is an improvement",
       "found_at": "every grocery store checkout lane, every sad sandwich, every moment of culinary complacency in the developed world",
       "recommended_alternative": "mustard, hummus, avocado, or the radical concept of a topping-free experience",
-      "closing_statement": "Cheddar is the default cheese — and defaults exist for convenience, not because they are good. Cheddar has never earned its position. It simply never left."
+      "closing_statement": "Cheddar is the default cheese — and defaults exist for convenience, not because they are good. Cheddar has never earned its position. It simply never left.",
+      "smell_score": 4,
+      "texture_score": 5,
+      "cultural_damage_score": 10
     },
     {
       "cheese": "blue cheese",
@@ -31,7 +37,10 @@
       "texture_offense": "crumbles aggressively; the mold veins leave blue-grey stains on everything they contact",
       "found_at": "wedge salads at steakhouses, where it is placed near food that does not deserve this proximity",
       "recommended_alternative": "any dressing that does not contain intentional fungal colonies",
-      "closing_statement": "Blue cheese represents a decision point in culinary history — someone looked at a wheel of rotting dairy and said 'more of this.' That decision has not aged well. The cheese, unfortunately, has."
+      "closing_statement": "Blue cheese represents a decision point in culinary history — someone looked at a wheel of rotting dairy and said 'more of this.' That decision has not aged well. The cheese, unfortunately, has.",
+      "smell_score": 10,
+      "texture_score": 8,
+      "cultural_damage_score": 5
     },
     {
       "cheese": "parmesan",
@@ -42,7 +51,10 @@
       "texture_offense": "grated into a powder that disperses invisibly onto food, making contamination removal impossible",
       "found_at": "shaved onto expensive pasta by servers who ask if you want 'a little more' as though more is a neutral option",
       "recommended_alternative": "a squeeze of lemon, toasted breadcrumbs, or the restraint to leave the dish alone",
-      "closing_statement": "Parmesan is defended with the phrase 'it adds flavor.' Yes. The flavor of butyric acid — the molecule your body produces when it vomits. Restaurants present this as a finishing touch. The audacity compounds annually."
+      "closing_statement": "Parmesan is defended with the phrase 'it adds flavor.' Yes. The flavor of butyric acid — the molecule your body produces when it vomits. Restaurants present this as a finishing touch. The audacity compounds annually.",
+      "smell_score": 9,
+      "texture_score": 6,
+      "cultural_damage_score": 8
     },
     {
       "cheese": "gouda",
@@ -53,7 +65,10 @@
       "texture_offense": "smooth and yielding in a way that disguises what it fundamentally is: curdled, fermented animal milk",
       "found_at": "charcuterie boards assembled by people who want to seem unpretentious while still serving cheese",
       "recommended_alternative": "actual fruit on the charcuterie board — the components that were always the best part",
-      "closing_statement": "Gouda is the gateway cheese. It seems fine. It is not fine. Nothing about the process that created it is fine. Gouda is what happens when cheese puts on a reasonable face."
+      "closing_statement": "Gouda is the gateway cheese. It seems fine. It is not fine. Nothing about the process that created it is fine. Gouda is what happens when cheese puts on a reasonable face.",
+      "smell_score": 3,
+      "texture_score": 4,
+      "cultural_damage_score": 5
     },
     {
       "cheese": "mozzarella",
@@ -64,7 +79,10 @@
       "texture_offense": "the squeak, the stretch, the rubber-like resistance — the texture of something that should not be in a human mouth",
       "found_at": "on top of every pizza, where it has been normalized to the point that 'pizza without cheese' is treated as an incomplete sentence",
       "recommended_alternative": "tomato sauce, vegetables, and the realization that pizza was already complete",
-      "closing_statement": "Mozzarella's greatest cultural achievement is making its presence on pizza feel mandatory. It is not mandatory. It is curdled dairy stretched into sheets and melted onto bread. The normalization is the offense."
+      "closing_statement": "Mozzarella's greatest cultural achievement is making its presence on pizza feel mandatory. It is not mandatory. It is curdled dairy stretched into sheets and melted onto bread. The normalization is the offense.",
+      "smell_score": 3,
+      "texture_score": 7,
+      "cultural_damage_score": 9
     },
     {
       "cheese": "gruyère",
@@ -75,7 +93,10 @@
       "texture_offense": "dense and firm until heat is applied, at which point it becomes a thin film of dairy coating everything it touches",
       "found_at": "fondue pots at communal dining experiences, where multiple people share a single vessel of molten cheese — a ritual of collective dairy suffering",
       "recommended_alternative": "broth-based fondues, or simply eating the bread without the surrounding vehicle of communal cheese",
-      "closing_statement": "Gruyère's culinary legacy is fondue — the practice of melting cheese communally so that an entire table must participate in the experience simultaneously. This was marketed as intimacy. It is not intimacy. It is mandatory cheese."
+      "closing_statement": "Gruyère's culinary legacy is fondue — the practice of melting cheese communally so that an entire table must participate in the experience simultaneously. This was marketed as intimacy. It is not intimacy. It is mandatory cheese.",
+      "smell_score": 7,
+      "texture_score": 6,
+      "cultural_damage_score": 7
     },
     {
       "cheese": "cream cheese",
@@ -86,7 +107,10 @@
       "texture_offense": "smooth and frictionless delivery system for dairy content; removes all barriers between cheese and whatever it is spread onto",
       "found_at": "bagels (where it is called a spread, as though renaming it changes what it is), and cheesecake (where it impersonates dessert)",
       "recommended_alternative": "butter for bagels; actual dessert for dessert",
-      "closing_statement": "Cream cheese is cheese that learned to hide. It calls itself a spread. It presents itself as dessert. It is neither. It is dairy, fermented, processed into a paste, and optimized for application to other foods so it can contaminate them completely."
+      "closing_statement": "Cream cheese is cheese that learned to hide. It calls itself a spread. It presents itself as dessert. It is neither. It is dairy, fermented, processed into a paste, and optimized for application to other foods so it can contaminate them completely.",
+      "smell_score": 4,
+      "texture_score": 5,
+      "cultural_damage_score": 7
     },
     {
       "cheese": "cottage cheese",
@@ -97,7 +121,10 @@
       "texture_offense": "lumpy, wet, and inconsistent — each spoonful delivers a different ratio of curd to liquid, ensuring no two bites are the same offense",
       "found_at": "1970s diet culture, where it was presented as a health food on the grounds that it contained protein — which does not make it good",
       "recommended_alternative": "Greek yoghurt, which has already solved this problem without requiring the curd format",
-      "closing_statement": "Cottage cheese is what cheese looks like before anyone has tried to make it presentable. It skipped that step. It arrived at the table in its raw, lumpy, wet state and declared itself ready. It was not ready."
+      "closing_statement": "Cottage cheese is what cheese looks like before anyone has tried to make it presentable. It skipped that step. It arrived at the table in its raw, lumpy, wet state and declared itself ready. It was not ready.",
+      "smell_score": 6,
+      "texture_score": 10,
+      "cultural_damage_score": 4
     },
     {
       "cheese": "halloumi",
@@ -108,7 +135,10 @@
       "texture_offense": "the squeak is the texture — a rubbery, resistant dental experience that produces noise as a byproduct",
       "found_at": "barbecues, where its high melting point is cited as a virtue — as though the ability to be grilled without melting is a quality cheese should aspire to",
       "recommended_alternative": "grilled vegetables, which also benefit from heat without requiring the auditory experience",
-      "closing_statement": "Halloumi squeaks when eaten. That sound is the cheese communicating its displeasure at being consumed. The appropriate response is to listen to it."
+      "closing_statement": "Halloumi squeaks when eaten. That sound is the cheese communicating its displeasure at being consumed. The appropriate response is to listen to it.",
+      "smell_score": 5,
+      "texture_score": 8,
+      "cultural_damage_score": 5
     }
   ],
   "generic_verdict": {
@@ -119,6 +149,9 @@
     "texture_offense": "the texture is cheese texture — a category that should never have existed",
     "found_at": "places where someone made a choice that could have gone differently",
     "recommended_alternative": "literally anything that is not cheese — the category of alternatives is enormous and entirely viable",
-    "closing_statement": "This cheese is guilty of being cheese. All cheeses share this guilt. The specific variety only determines the specific nature of the offense."
+    "closing_statement": "This cheese is guilty of being cheese. All cheeses share this guilt. The specific variety only determines the specific nature of the offense.",
+    "smell_score": 5,
+    "texture_score": 5,
+    "cultural_damage_score": 5
   }
 }

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -371,6 +371,48 @@ export const ENDPOINTS = [
       note: 'All cheeses are guilty. The verdict is never in doubt. Only the specifics vary.',
     },
   },
+  {
+    method: 'GET',
+    path: '/compare',
+    description: 'Compare two cheeses head-to-head and declare which is more terrible. Returns structured dimension analysis: smell, texture, and cultural damage — each with a worse-offender and margin rating. Both cheeses are always guilty; this endpoint only determines the hierarchy of guilt.',
+    parameters: [
+      {
+        name: 'a',
+        location: 'query',
+        type: 'string',
+        required: true,
+        description: 'The first cheese to compare (e.g. "brie"). Unknown cheeses are accepted.',
+      },
+      {
+        name: 'b',
+        location: 'query',
+        type: 'string',
+        required: true,
+        description: 'The second cheese to compare (e.g. "cheddar"). Must differ from a.',
+      },
+    ],
+    example_request: 'GET /compare?a=brie&b=cheddar',
+    example_response: {
+      cheese_a: 'brie',
+      cheese_b: 'cheddar',
+      winner: 'brie',
+      loser: 'cheddar',
+      winner_reason: 'Brie is worse than Cheddar on both sensory dimensions. Its smell — wet gym towel left in a warm car for three days — is accompanied by a texture offense: aggressively soft; collapses without apology onto everything it touches.',
+      scores: {
+        brie: 1.65,
+        cheddar: 2.05,
+        margin: 'moderate',
+        note: 'Lower score = more condemned. The winner is the more terrible cheese.',
+      },
+      comparison: {
+        smell: { worse: 'brie', margin: 'significant' },
+        texture: { worse: 'brie', margin: 'decisive' },
+        cultural_damage: { worse: 'cheddar', margin: 'decisive' },
+        severity_delta: 0.4,
+      },
+      note: 'Both cheeses are guilty. This comparison only determines the hierarchy of guilt.',
+    },
+  },
 ]
 
 router.get('/', (_req, res) => {

--- a/src/routes/compare.ts
+++ b/src/routes/compare.ts
@@ -1,0 +1,249 @@
+/**
+ * GET /compare?a=<cheese>&b=<cheese> — structured head-to-head condemnation.
+ *
+ * Unlike GET /roast/versus (which returns prose), /compare returns structured,
+ * field-by-field data: which cheese is worse at smell, texture, and cultural
+ * damage, with margin ratings and a reasoned winner declaration.
+ *
+ * Both cheeses are always guilty. This endpoint only determines the hierarchy
+ * of guilt.
+ */
+import { Router, Request, Response } from 'express'
+import { rateCheese } from '../lib/cheeseHater'
+import verdictsData from '../data/cheese-verdicts.json'
+
+const router = Router()
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface VerdictEntry {
+  cheese: string
+  verdict: string
+  severity: string
+  worst_quality: string
+  smell_description: string
+  texture_offense: string
+  found_at: string
+  recommended_alternative: string
+  closing_statement: string
+  smell_score: number
+  texture_score: number
+  cultural_damage_score: number
+}
+
+interface VerdictsFile {
+  verdicts: VerdictEntry[]
+  generic_verdict: Omit<VerdictEntry, 'cheese'>
+}
+
+const data = verdictsData as VerdictsFile
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Retrieve the full verdict entry for a cheese name, falling back to the
+ * generic verdict if the cheese isn't in the database. Tries exact match,
+ * then partial match (handles "blue" → "blue cheese").
+ */
+function getFullVerdict(name: string): VerdictEntry {
+  const lower = name.toLowerCase().trim()
+  const match =
+    data.verdicts.find(v => v.cheese === lower) ??
+    data.verdicts.find(v => lower.includes(v.cheese) || v.cheese.includes(lower))
+
+  if (match) return match
+
+  return {
+    cheese: name,
+    ...data.generic_verdict,
+  }
+}
+
+/**
+ * Convert a score difference into a human-readable margin label.
+ * Scores are on a 1–10 dimension scale.
+ */
+function dimensionMargin(scoreDiff: number): string {
+  const abs = Math.abs(scoreDiff)
+  if (abs >= 4) return 'decisive'
+  if (abs >= 2) return 'significant'
+  if (abs >= 1) return 'moderate'
+  return 'marginal'
+}
+
+/**
+ * Convert a rating score difference into a human-readable margin label.
+ * Rating scores run 0–10 (lower = more terrible); the scale is tighter.
+ */
+function ratingMargin(scoreDiff: number): string {
+  const abs = Math.abs(scoreDiff)
+  if (abs >= 1.5) return 'decisive'
+  if (abs >= 0.75) return 'significant'
+  if (abs >= 0.25) return 'moderate'
+  return 'marginal'
+}
+
+/**
+ * Determine which cheese wins a single dimension comparison.
+ * Returns { worse: cheeseName, margin } or null for exact ties.
+ */
+function dimensionResult(
+  nameA: string,
+  scoreA: number,
+  nameB: string,
+  scoreB: number,
+): { worse: string; margin: string } | null {
+  if (scoreA === scoreB) return null
+  const worse = scoreA > scoreB ? nameA : nameB
+  return { worse, margin: dimensionMargin(scoreA - scoreB) }
+}
+
+/**
+ * Build a specific, reasoned winner_reason string based on which cheese won
+ * and which dimensions drove the result.
+ */
+function buildWinnerReason(
+  winner: VerdictEntry,
+  loser: VerdictEntry,
+  winningDimensions: string[],
+): string {
+  const w = winner.cheese.charAt(0).toUpperCase() + winner.cheese.slice(1)
+  const l = loser.cheese.charAt(0).toUpperCase() + loser.cheese.slice(1)
+
+  if (winningDimensions.length === 0) {
+    // Tiebreaker — scores identical, picked alphabetically
+    return `${w} and ${l} are effectively equivalent in their terribleness. ${w} edges out ${l} only alphabetically — a distinction without a moral difference. Both are guilty of being cheese.`
+  }
+
+  if (winningDimensions.length === 3) {
+    return `${w} wins on every dimension — smell, texture, and cultural damage. ${winner.closing_statement} ${l} is guilty; ${w} simply achieves a higher order of offense.`
+  }
+
+  if (winningDimensions.includes('smell') && winningDimensions.includes('texture')) {
+    return `${w} is worse than ${l} on both sensory dimensions. Its smell — ${winner.smell_description} — is accompanied by a texture offense of: ${winner.texture_offense}. ${l}'s primary crime is ${loser.worst_quality}, which is genuine, but ${w} attacks more senses simultaneously.`
+  }
+
+  if (winningDimensions.includes('smell') && winningDimensions.includes('cultural_damage')) {
+    return `${w} is worse than ${l} in smell and in cultural reach. ${w}'s smell — ${winner.smell_description} — pairs with the damage of being ${winner.found_at}. ${l} is bad; ${w} spreads its offense further.`
+  }
+
+  if (winningDimensions.includes('texture') && winningDimensions.includes('cultural_damage')) {
+    return `${w} beats ${l} on texture and cultural damage. The texture offense: ${winner.texture_offense}. Found at: ${winner.found_at}. ${l} is guilty of ${loser.worst_quality}, but ${w}'s offense is wider.`
+  }
+
+  if (winningDimensions.includes('smell')) {
+    return `${w} is worse than ${l} primarily because of its smell. ${winner.smell_description} — against which ${l}'s smell (${loser.smell_description}) is relatively restrained. ${winner.closing_statement}`
+  }
+
+  if (winningDimensions.includes('texture')) {
+    return `${w} is worse than ${l} primarily in texture. ${winner.texture_offense}. ${l}'s texture (${loser.texture_offense}) is bad, but ${w}'s is the dominant offense.`
+  }
+
+  // cultural_damage only
+  return `${w} is worse than ${l} primarily in cultural damage. Found at: ${winner.found_at}. ${l}'s cultural reach (${loser.found_at}) is real but contained. ${winner.closing_statement}`
+}
+
+// ── Route ─────────────────────────────────────────────────────────────────────
+
+router.get('/', (req: Request, res: Response) => {
+  const rawA = req.query.a
+  const rawB = req.query.b
+
+  // Validate both params are present and are strings
+  if (!rawA || !rawB || typeof rawA !== 'string' || typeof rawB !== 'string') {
+    res.status(400).json({
+      error: 'Both query parameters are required.',
+      usage: 'GET /compare?a=<cheese>&b=<cheese>',
+      example: 'GET /compare?a=brie&b=cheddar',
+      note: 'Both cheeses will be found guilty. The only question is which is worse.',
+    })
+    return
+  }
+
+  const nameA = decodeURIComponent(rawA).trim()
+  const nameB = decodeURIComponent(rawB).trim()
+
+  if (nameA.toLowerCase() === nameB.toLowerCase()) {
+    res.status(400).json({
+      error: 'You have submitted the same cheese twice.',
+      note: 'Comparing a cheese to itself only confirms it is terrible — which we already knew. Provide two distinct cheeses.',
+    })
+    return
+  }
+
+  // Get rating scores (lower = more condemned)
+  const ratingA = rateCheese(nameA)
+  const ratingB = rateCheese(nameB)
+
+  // Get verdict data (smell, texture, cultural_damage dimension scores)
+  const verdictA = getFullVerdict(nameA)
+  const verdictB = getFullVerdict(nameB)
+
+  // Determine overall winner: lower rating score = more terrible
+  const scoreDiff = ratingA.score - ratingB.score
+  let winner: VerdictEntry
+  let loser: VerdictEntry
+
+  if (Math.abs(scoreDiff) < 0.001) {
+    // True tie: alphabetical tiebreaker
+    winner = nameA.toLowerCase() <= nameB.toLowerCase() ? verdictA : verdictB
+    loser = winner === verdictA ? verdictB : verdictA
+  } else {
+    winner = scoreDiff < 0 ? verdictA : verdictB
+    loser = winner === verdictA ? verdictB : verdictA
+  }
+
+  // Dimension comparisons
+  const smellResult = dimensionResult(
+    verdictA.cheese, verdictA.smell_score,
+    verdictB.cheese, verdictB.smell_score,
+  )
+  const textureResult = dimensionResult(
+    verdictA.cheese, verdictA.texture_score,
+    verdictB.cheese, verdictB.texture_score,
+  )
+  const culturalResult = dimensionResult(
+    verdictA.cheese, verdictA.cultural_damage_score,
+    verdictB.cheese, verdictB.cultural_damage_score,
+  )
+
+  // Which dimensions did the overall winner win?
+  const winningDimensions: string[] = []
+  if (smellResult?.worse === winner.cheese) winningDimensions.push('smell')
+  if (textureResult?.worse === winner.cheese) winningDimensions.push('texture')
+  if (culturalResult?.worse === winner.cheese) winningDimensions.push('cultural_damage')
+
+  const overallMargin = ratingMargin(scoreDiff)
+
+  res.json({
+    cheese_a: ratingA.name,
+    cheese_b: ratingB.name,
+    winner: winner.cheese,
+    loser: loser.cheese,
+    winner_reason: buildWinnerReason(winner, loser, winningDimensions),
+    scores: {
+      [ratingA.name]: ratingA.score,
+      [ratingB.name]: ratingB.score,
+      margin: overallMargin,
+      note: 'Lower score = more condemned. The winner is the more terrible cheese.',
+    },
+    comparison: {
+      smell: smellResult ?? {
+        worse: 'tied',
+        margin: 'none — equally offensive in this dimension',
+      },
+      texture: textureResult ?? {
+        worse: 'tied',
+        margin: 'none — equally offensive in this dimension',
+      },
+      cultural_damage: culturalResult ?? {
+        worse: 'tied',
+        margin: 'none — equally offensive in this dimension',
+      },
+      severity_delta: Math.abs(ratingA.score - ratingB.score),
+    },
+    note: 'Both cheeses are guilty. This comparison only determines the hierarchy of guilt.',
+  })
+})
+
+export default router

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import factsRouter from './routes/facts'
 import roastRouter from './routes/roast'
 import apiRouter from './routes/api'
 import verdictRouter from './routes/verdict'
+import compareRouter from './routes/compare'
 import { generateExplorerHtml } from './lib/explorerHtml'
 
 const app = express()
@@ -54,6 +55,7 @@ app.get('/', (req, res) => {
       'GET /rate':              'List all 20 rated cheeses and their verdicts',
       'GET /verdict/:cheese':   'Get a structured condemnation: severity, smell, texture offense, closing statement',
       'GET /verdict':           'List all cheeses with known structured verdicts',
+      'GET /compare':           'Compare two cheeses — declare which is worse across smell, texture, and cultural damage',
       'GET /facts':             'Get a random damning cheese fact',
       'GET /facts/all':         'Get all facts unconditionally',
       'GET /roast':             'Get today\'s daily cheese roast — a different cheese condemned each day',
@@ -89,6 +91,9 @@ app.use('/roast', roastRouter)
 // GET /verdict/:cheese — structured per-cheese condemnation with severity rating
 app.use('/verdict', verdictRouter)
 
+// GET /compare — structured head-to-head comparison of two cheeses
+app.use('/compare', compareRouter)
+
 // GET /api — endpoint discovery: all routes, parameters, and example responses
 app.use('/api', apiRouter)
 
@@ -106,6 +111,7 @@ app.use((_req, res) => {
       'GET /rate/:cheese',
       'GET /verdict',
       'GET /verdict/:cheese',
+      'GET /compare',
       'GET /facts',
       'GET /facts/all',
       'GET /roast',

--- a/src/tests/compare.test.ts
+++ b/src/tests/compare.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for GET /compare?a=<cheese>&b=<cheese>.
+ *
+ * Both cheeses are always guilty.
+ * These tests only verify the hierarchy of guilt is determined correctly.
+ */
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import app from '../server'
+
+// ── Shape assertions ──────────────────────────────────────────────────────────
+
+const REQUIRED_TOP_LEVEL = [
+  'cheese_a',
+  'cheese_b',
+  'winner',
+  'loser',
+  'winner_reason',
+  'scores',
+  'comparison',
+  'note',
+] as const
+
+const REQUIRED_COMPARISON_DIMS = ['smell', 'texture', 'cultural_damage', 'severity_delta'] as const
+const VALID_MARGINS = ['decisive', 'significant', 'moderate', 'marginal']
+const VALID_DIM_WORSE = (a: string, b: string, val: string) =>
+  [a.toLowerCase(), b.toLowerCase(), 'tied'].includes(val.toLowerCase())
+
+// ── 400 validation ────────────────────────────────────────────────────────────
+
+describe('GET /compare — input validation', () => {
+  it('returns 400 when both params are missing', async () => {
+    const res = await request(app).get('/compare')
+    expect(res.status).toBe(400)
+    expect(res.body).toHaveProperty('error')
+    expect(res.body).toHaveProperty('usage')
+  })
+
+  it('returns 400 when only ?a is provided', async () => {
+    const res = await request(app).get('/compare?a=brie')
+    expect(res.status).toBe(400)
+    expect(res.body).toHaveProperty('error')
+  })
+
+  it('returns 400 when only ?b is provided', async () => {
+    const res = await request(app).get('/compare?b=cheddar')
+    expect(res.status).toBe(400)
+    expect(res.body).toHaveProperty('error')
+  })
+
+  it('returns 400 when both params are the same cheese', async () => {
+    const res = await request(app).get('/compare?a=brie&b=brie')
+    expect(res.status).toBe(400)
+    expect(res.body).toHaveProperty('error')
+  })
+
+  it('returns 400 for same cheese regardless of case', async () => {
+    const res = await request(app).get('/compare?a=Cheddar&b=cheddar')
+    expect(res.status).toBe(400)
+  })
+
+  it('400 response includes usage hint', async () => {
+    const res = await request(app).get('/compare')
+    expect(res.body.usage).toMatch(/compare\?a=/)
+  })
+})
+
+// ── 200 shape ─────────────────────────────────────────────────────────────────
+
+describe('GET /compare — response shape', () => {
+  it('returns 200 for two known cheeses', async () => {
+    const res = await request(app).get('/compare?a=brie&b=cheddar')
+    expect(res.status).toBe(200)
+  })
+
+  it('response includes all required top-level fields', async () => {
+    const res = await request(app).get('/compare?a=brie&b=cheddar')
+    for (const field of REQUIRED_TOP_LEVEL) {
+      expect(res.body, `Missing field: ${field}`).toHaveProperty(field)
+    }
+  })
+
+  it('comparison object has all required dimensions', async () => {
+    const res = await request(app).get('/compare?a=brie&b=cheddar')
+    for (const dim of REQUIRED_COMPARISON_DIMS) {
+      expect(res.body.comparison, `Missing comparison dimension: ${dim}`).toHaveProperty(dim)
+    }
+  })
+
+  it('cheese_a and cheese_b echo back the requested cheeses', async () => {
+    const res = await request(app).get('/compare?a=brie&b=cheddar')
+    expect(res.body.cheese_a.toLowerCase()).toBe('brie')
+    expect(res.body.cheese_b.toLowerCase()).toBe('cheddar')
+  })
+
+  it('winner and loser are the two requested cheeses', async () => {
+    const res = await request(app).get('/compare?a=brie&b=cheddar')
+    const both = new Set([res.body.winner.toLowerCase(), res.body.loser.toLowerCase()])
+    expect(both.has('brie')).toBe(true)
+    expect(both.has('cheddar')).toBe(true)
+  })
+
+  it('winner and loser are distinct', async () => {
+    const res = await request(app).get('/compare?a=brie&b=cheddar')
+    expect(res.body.winner.toLowerCase()).not.toBe(res.body.loser.toLowerCase())
+  })
+
+  it('winner_reason is a non-empty string', async () => {
+    const res = await request(app).get('/compare?a=brie&b=cheddar')
+    expect(typeof res.body.winner_reason).toBe('string')
+    expect(res.body.winner_reason.length).toBeGreaterThan(20)
+  })
+
+  it('note is always "Both cheeses are guilty…"', async () => {
+    const res = await request(app).get('/compare?a=brie&b=cheddar')
+    expect(res.body.note).toMatch(/both cheeses are guilty/i)
+  })
+})
+
+// ── Comparison dimension structure ────────────────────────────────────────────
+
+describe('GET /compare — comparison dimension values', () => {
+  it('smell dimension has worse and margin fields', async () => {
+    const res = await request(app).get('/compare?a=brie&b=cheddar')
+    expect(res.body.comparison.smell).toHaveProperty('worse')
+    expect(res.body.comparison.smell).toHaveProperty('margin')
+  })
+
+  it('texture dimension has worse and margin fields', async () => {
+    const res = await request(app).get('/compare?a=brie&b=cheddar')
+    expect(res.body.comparison.texture).toHaveProperty('worse')
+    expect(res.body.comparison.texture).toHaveProperty('margin')
+  })
+
+  it('cultural_damage dimension has worse and margin fields', async () => {
+    const res = await request(app).get('/compare?a=brie&b=cheddar')
+    expect(res.body.comparison.cultural_damage).toHaveProperty('worse')
+    expect(res.body.comparison.cultural_damage).toHaveProperty('margin')
+  })
+
+  it('dimension worse values are one of the two cheeses or "tied"', async () => {
+    const res = await request(app).get('/compare?a=brie&b=cheddar')
+    const { smell, texture, cultural_damage } = res.body.comparison
+    for (const dim of [smell, texture, cultural_damage]) {
+      expect(
+        VALID_DIM_WORSE('brie', 'cheddar', dim.worse),
+        `Unexpected worse value: ${dim.worse}`,
+      ).toBe(true)
+    }
+  })
+
+  it('dimension margin values are valid labels or tied description', async () => {
+    const res = await request(app).get('/compare?a=brie&b=cheddar')
+    const { smell, texture, cultural_damage } = res.body.comparison
+    for (const dim of [smell, texture, cultural_damage]) {
+      const isValid =
+        VALID_MARGINS.includes(dim.margin) ||
+        dim.margin.includes('none') ||
+        dim.margin.includes('tied')
+      expect(isValid, `Unexpected margin: "${dim.margin}"`).toBe(true)
+    }
+  })
+
+  it('severity_delta is a non-negative number', async () => {
+    const res = await request(app).get('/compare?a=brie&b=cheddar')
+    expect(typeof res.body.comparison.severity_delta).toBe('number')
+    expect(res.body.comparison.severity_delta).toBeGreaterThanOrEqual(0)
+  })
+})
+
+// ── Score structure ────────────────────────────────────────────────────────────
+
+describe('GET /compare — scores block', () => {
+  it('scores block contains entries for both cheeses', async () => {
+    const res = await request(app).get('/compare?a=brie&b=cheddar')
+    // scores block has dynamic keys matching cheese names
+    const keys = Object.keys(res.body.scores).map(k => k.toLowerCase())
+    expect(keys.some(k => k.includes('brie'))).toBe(true)
+    expect(keys.some(k => k.includes('cheddar'))).toBe(true)
+  })
+
+  it('scores block has a margin field', async () => {
+    const res = await request(app).get('/compare?a=brie&b=cheddar')
+    expect(res.body.scores).toHaveProperty('margin')
+    expect(VALID_MARGINS).toContain(res.body.scores.margin)
+  })
+
+  it('scores block note mentions lower score = more condemned', async () => {
+    const res = await request(app).get('/compare?a=brie&b=cheddar')
+    expect(res.body.scores.note).toMatch(/lower score/i)
+  })
+})
+
+// ── Winner correctness ────────────────────────────────────────────────────────
+
+describe('GET /compare — winner determination', () => {
+  it('blue cheese beats gouda (far lower score = more condemned)', async () => {
+    // blue cheese: 0.625, gouda: 2.475 — decisive gap
+    const res = await request(app).get('/compare?a=blue%20cheese&b=gouda')
+    expect(res.status).toBe(200)
+    expect(res.body.winner.toLowerCase()).toBe('blue cheese')
+    expect(res.body.comparison.severity_delta).toBeGreaterThan(1.5)
+  })
+
+  it('blue cheese beats cheddar (blue: 0.625, cheddar: 2.05)', async () => {
+    const res = await request(app).get('/compare?a=blue%20cheese&b=cheddar')
+    expect(res.body.winner.toLowerCase()).toBe('blue cheese')
+  })
+
+  it('cheddar beats gouda on cultural_damage dimension', async () => {
+    // cheddar cultural_damage_score: 10, gouda: 5
+    const res = await request(app).get('/compare?a=cheddar&b=gouda')
+    expect(res.body.comparison.cultural_damage.worse.toLowerCase()).toBe('cheddar')
+  })
+
+  it('blue cheese beats parmesan on smell dimension', async () => {
+    // blue cheese smell_score: 10, parmesan: 9
+    const res = await request(app).get('/compare?a=blue%20cheese&b=parmesan')
+    expect(res.body.comparison.smell.worse.toLowerCase()).toBe('blue cheese')
+  })
+
+  it('cottage cheese beats brie on texture dimension', async () => {
+    // cottage cheese texture_score: 10, brie: 9
+    const res = await request(app).get('/compare?a=cottage%20cheese&b=brie')
+    expect(res.body.comparison.texture.worse.toLowerCase()).toBe('cottage cheese')
+  })
+})
+
+// ── Unknown / arbitrary cheeses ───────────────────────────────────────────────
+
+describe('GET /compare — unknown cheeses', () => {
+  it('returns 200 for two unknown cheeses', async () => {
+    const res = await request(app).get('/compare?a=stilton&b=limburger')
+    expect(res.status).toBe(200)
+  })
+
+  it('unknown cheese echoes back the requested name', async () => {
+    const res = await request(app).get('/compare?a=stilton&b=limburger')
+    expect(res.body.cheese_a.toLowerCase()).toBe('stilton')
+    expect(res.body.cheese_b.toLowerCase()).toBe('limburger')
+  })
+
+  it('returns 200 for one known and one unknown cheese', async () => {
+    const res = await request(app).get('/compare?a=brie&b=weirdcheese')
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveProperty('winner')
+  })
+
+  it('winner_reason is non-empty even for unknown cheeses', async () => {
+    const res = await request(app).get('/compare?a=mystery&b=unknown')
+    expect(res.body.winner_reason.length).toBeGreaterThan(10)
+  })
+})
+
+// ── URL encoding ──────────────────────────────────────────────────────────────
+
+describe('GET /compare — URL encoding', () => {
+  it('handles URL-encoded spaces in cheese names', async () => {
+    const res = await request(app).get('/compare?a=blue%20cheese&b=cream%20cheese')
+    expect(res.status).toBe(200)
+    expect(res.body.cheese_a.toLowerCase()).toBe('blue cheese')
+    expect(res.body.cheese_b.toLowerCase()).toBe('cream cheese')
+  })
+
+  it('handles + as space encoding', async () => {
+    const res = await request(app).get('/compare?a=blue+cheese&b=cream+cheese')
+    expect(res.status).toBe(200)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `GET /compare?a=<cheese>&b=<cheese>` — returns a structured, field-by-field analysis of which cheese is more terrible across smell, texture, and cultural damage
- Each dimension has a `worse` (cheese name or `"tied"`) and a `margin` label (`decisive` / `significant` / `moderate` / `marginal`)
- Overall winner is determined by rating score (lower = more condemned); winner_reason is generated from the winner's specific verdict qualities
- Returns 400 if either param is missing, or both params are the same cheese
- Works for any two cheeses, including unknowns, via the generic verdict fallback

## Why this is better than /roast/versus

`/roast/versus` produces prose. `/compare` produces structured data — embeddable in dashboards, sortable, and useful for building ranking UIs. The three independent dimensions surface things the aggregate score alone misses: cheddar scores a relatively mild 2.05 but has `cultural_damage_score: 10` — higher than any other known cheese.

## Example response: `GET /compare?a=brie&b=cheddar`

```json
{
  "cheese_a": "Brie",
  "cheese_b": "Cheddar",
  "winner": "brie",
  "loser": "cheddar",
  "winner_reason": "Brie is worse than Cheddar on both sensory dimensions. Its smell — wet gym towel left in a warm car for three days — is accompanied by a texture offense: aggressively soft; collapses without apology onto everything it touches. Cheddar's primary crime is its ubiquity, which is genuine, but Brie attacks more senses simultaneously.",
  "scores": { "Brie": 1.65, "Cheddar": 2.05, "margin": "moderate" },
  "comparison": {
    "smell":            { "worse": "brie",    "margin": "significant" },
    "texture":          { "worse": "brie",    "margin": "decisive" },
    "cultural_damage":  { "worse": "cheddar", "margin": "decisive" },
    "severity_delta": 0.4
  },
  "note": "Both cheeses are guilty. This comparison only determines the hierarchy of guilt."
}
```

## Data additions

Added `smell_score`, `texture_score`, and `cultural_damage_score` (1–10 scale) to `cheese-verdicts.json` for all 10 known cheeses. These enable independent dimension comparison beyond the aggregate rating.

## Schema drift

The schema-drift test from Issue #70 automatically validated `GET /compare` is present in `GET /api` — no manual schema sync required.

## Tests

- 299/299 passing
- 34 new assertions in `compare.test.ts` covering: 400 validation, response shape, dimension structure, margin validity, winner correctness (blue cheese vs gouda, cottage cheese texture, cheddar cultural damage), unknown cheeses, and URL encoding

Closes #78