### PR TITLE
[cheese-hater] Add GET /worst — ranked list of all cheeses by condemnation severity

### DIFF
--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -413,6 +413,60 @@ export const ENDPOINTS = [
       note: 'Both cheeses are guilty. This comparison only determines the hierarchy of guilt.',
     },
   },
+  {
+    method: 'GET',
+    path: '/worst',
+    description: 'All cheeses ranked from most to least terrible by score, each annotated with a severity tier and a why_it_wins explanation. Supports filtering by tier and limiting results. GET /worst?limit=1 returns the single worst cheese in the database.',
+    parameters: [
+      {
+        name: 'tier',
+        location: 'query',
+        type: 'string',
+        required: false,
+        description: 'Filter by severity tier: "catastrophic" (score < 1.0), "revolting" (score 1.0–1.99), or "condemned" (score 2.0+).',
+      },
+      {
+        name: 'limit',
+        location: 'query',
+        type: 'number',
+        required: false,
+        description: 'Return only the top N entries. Default: all cheeses.',
+      },
+    ],
+    example_request: 'GET /worst?limit=3',
+    example_response: {
+      ranked: [
+        {
+          rank: 1,
+          cheese: 'Casu Martzu',
+          score: 0.125,
+          severity_tier: 'catastrophic',
+          verdict: 'CATASTROPHIC',
+          why_it_wins: 'Contains live maggots — cheese fly larvae deliberately left to eat through the interior. Illegal to sell in the EU. Still consumed. This is what cheese becomes when you follow its logic without regulatory constraint.',
+        },
+        {
+          rank: 2,
+          cheese: 'Blue Cheese',
+          score: 0.625,
+          severity_tier: 'catastrophic',
+          verdict: 'CATASTROPHIC',
+          why_it_wins: 'Deliberately cultivated mold injected throughout with Penicillium spores. Someone looked at a rotting wheel of dairy and said "more of this." That person was wrong.',
+        },
+        {
+          rank: 3,
+          cheese: 'Stilton',
+          score: 0.925,
+          severity_tier: 'catastrophic',
+          verdict: 'CATASTROPHIC',
+          why_it_wins: 'A Protected Designation of Origin cheese — meaning the EU has legal geographic restrictions on which farms can produce this specific variety of mold-veined aged dairy.',
+        },
+      ],
+      total: 3,
+      total_in_database: 21,
+      limit: 3,
+      note: 'Ranked from most terrible to least. The least terrible cheese on this list is still cheese.',
+    },
+  },
 ]
 
 router.get('/', (_req, res) => {

--- a/src/routes/worst.ts
+++ b/src/routes/worst.ts
@@ -1,0 +1,160 @@
+/**
+ * GET /worst — all cheeses ranked from most to least terrible.
+ *
+ * Answers the question every cheese-hater actually has: which cheese is
+ * the worst of all? Sorted ascending by score (lower = more condemned),
+ * with each entry annotated with a severity_tier and a why_it_wins field
+ * that makes the ranking self-contained and quotable.
+ *
+ * Query params:
+ *   ?tier=catastrophic|revolting|condemned   — filter by severity tier
+ *   ?limit=N                                 — return only top N entries
+ */
+import { Router, Request, Response } from 'express'
+import { ratings } from '../lib/cheeseHater'
+
+const router = Router()
+
+// ── Per-cheese annotations ────────────────────────────────────────────────────
+// why_it_wins: a single devastating sentence (or two) explaining why this
+// cheese earns its rank. Factual. Specific. Unsparing.
+
+const WHY_IT_WINS: Record<string, string> = {
+  'Casu Martzu':
+    'Contains live maggots — cheese fly larvae deliberately left to eat through the interior and accelerate fermentation. Illegal to sell in the EU. Still consumed in Sardinia. This is what cheese becomes when you follow its awful logic without regulatory constraint.',
+
+  'Blue Cheese':
+    'Deliberately cultivated mold injected throughout with Penicillium spores, then pierced with metal rods to spread the growth. Someone looked at a wheel of rotting dairy and said "more of this." That decision has not aged well. The cheese, unfortunately, has.',
+
+  'Stilton':
+    'A Protected Designation of Origin product — meaning the EU has legal geographic restrictions on which farms can produce this specific variety of mold-veined aged dairy. The legal apparatus exists to protect it. This has not made it acceptable.',
+
+  'Époisses':
+    'Banned from French public transport due to its smell. France — a country with a documented cheese culture — decided this cheese could not be carried on a bus. The country that gave the world brie drew a line. Époisses was on the wrong side of it.',
+
+  'Limburger':
+    'Ripened by Brevibacterium linens — the same bacteria that produce human body odour, specifically the smell of feet. Not similar bacteria. The exact same species. Limburger smells like feet because it is made with foot bacteria. This is the fact.',
+
+  'Cottage Cheese':
+    'Exists in discrete wet lumps suspended in liquid — a format that even dedicated cheese consumers struggle to defend aesthetically. It is what cheese looks like before anyone has tried to make it presentable. It skipped that step entirely.',
+
+  'Camembert':
+    'A soft-ripened cheese with a white mold rind, functionally identical to brie in its mold-rind offense but with a stronger smell and a more assertive interior that liquefies as it reaches what producers call "peak ripeness."',
+
+  'Brie':
+    'The rind is legally edible mold. This is the selling point. Favoured by people who want to seem sophisticated while eating something that smells like old feet — especially at room temperature at a party where no one is watching the cheese plate.',
+
+  'American Cheese':
+    'Not legally cheese in the United States — classified as "processed cheese product" because it fails to meet minimum cheese content thresholds by definition. It is cheese-adjacent processed dairy, which makes it worse than actual cheese in almost every respect.',
+
+  'Mozzarella':
+    'Pre-shredded mozzarella is coated in cellulose — wood pulp fibre — to prevent clumping. You are not buying shredded cheese. You are buying cheese coated in wood pulp, sold without prominent labelling. The food industry decided this was fine.',
+
+  'Velveeta':
+    'Also classified as "processed cheese product," not cheese. Engineered to melt smoothly via sodium citrate, sodium phosphate, and calcium phosphate. The smoothness is not natural. The product is not natural. The category barely qualifies as food.',
+
+  'Feta':
+    'A Protected Designation of Origin brined cheese — meaning the EU has legal protections for this specific process of submerging dairy in salt water for months. The legal apparatus protects it. The result is still a wet, crumbled, salty dairy product.',
+
+  'Provolone':
+    'An aged Italian cheese whose flavor proponents describe as "sharp" and "tangy" — the industry\'s way of saying it tastes of accelerated decay. It is strung into forms and hung to dry. The hanging is not an improvement. The description is accurate.',
+
+  'Halloumi':
+    'Squeaks against teeth when eaten. That sound is the cheese communicating its displeasure at being consumed. The appropriate response is to listen to it. The fact that grilling it is considered a virtue only confirms that heat was the last option.',
+
+  'Cream Cheese':
+    'Has learned to hide. It calls itself a spread. It presents itself as dessert in cheesecake. It is neither. It is fermented dairy processed into a paste, optimised for applying to other foods uniformly and completely, ensuring total contamination.',
+
+  'Gruyère':
+    'Melts exceptionally well — which means it spreads its offense across a larger surface area than most cheeses achieve. Used in fondue: communal molten cheese shared from a single pot. Switzerland\'s cheese industry invented this tradition in the 1960s to move product.',
+
+  'Parmesan':
+    'Contains butyric acid — the same chemical compound present in human vomit. This is chemistry, not metaphor. Restaurants shave it onto expensive food as a finishing touch and ask if you want "a little more," as though more were a neutral option.',
+
+  'Cheddar':
+    'The most ubiquitous offense. Cheddar is everywhere — every grocery store, every sad sandwich, every moment of culinary complacency. Its ubiquity has normalised it. Normalisation has not improved it. Cheddar has never earned its position. It simply never left.',
+
+  'Ricotta':
+    'Made from whey — the liquid byproduct left over after producing other cheese. Ricotta is the dairy industry\'s use of what remains after the primary offense has been committed. It is cheese made from the runoff of cheese-making. The cycle is complete.',
+
+  'Swiss (Emmental)':
+    'Has holes. The holes are the result of gas-producing bacteria fermenting inside the cheese during aging. The defining visual feature of Swiss cheese is evidence of bacterial activity. This is considered a quality indicator by the people who sell it.',
+
+  'Gouda':
+    'The gateway cheese — mild, approachable, almost reasonable-seeming. This is precisely how gateway cheeses operate. Gouda has the lowest offense score on this list. It is still cheese. Nothing about the process that produced it changed because it seems fine.',
+}
+
+// Map from cheese-ratings.json verdict strings to tier labels
+const VERDICT_TO_TIER: Record<string, string> = {
+  CATASTROPHIC: 'catastrophic',
+  REVOLTING:    'revolting',
+  CONDEMNED:    'condemned',
+}
+
+const VALID_TIERS = new Set(['catastrophic', 'revolting', 'condemned'])
+
+// ── Route ─────────────────────────────────────────────────────────────────────
+
+router.get('/', (req: Request, res: Response) => {
+  // --- query param validation ---
+  const tierParam = req.query.tier
+  const limitParam = req.query.limit
+
+  if (tierParam !== undefined) {
+    if (typeof tierParam !== 'string' || !VALID_TIERS.has(tierParam.toLowerCase())) {
+      res.status(400).json({
+        error: 'Invalid tier value.',
+        valid_tiers: ['catastrophic', 'revolting', 'condemned'],
+        note: 'Every tier is bad. These are only the categories of bad.',
+      })
+      return
+    }
+  }
+
+  let limit: number | null = null
+  if (limitParam !== undefined) {
+    limit = parseInt(String(limitParam), 10)
+    if (isNaN(limit) || limit < 1) {
+      res.status(400).json({
+        error: 'Invalid limit value. Must be a positive integer.',
+        example: 'GET /worst?limit=5',
+      })
+      return
+    }
+  }
+
+  // --- build ranked list (ascending score = most terrible first) ---
+  const sorted = [...ratings].sort((a, b) => a.score - b.score)
+
+  let ranked = sorted.map((r, idx) => ({
+    rank: idx + 1,
+    cheese: r.name,
+    score: r.score,
+    severity_tier: VERDICT_TO_TIER[r.verdict] ?? r.verdict.toLowerCase(),
+    verdict: r.verdict,
+    why_it_wins:
+      WHY_IT_WINS[r.name] ??
+      `${r.name} is cheese. Cheese is terrible. Its score of ${r.score} reflects this accurately and without sentiment.`,
+  }))
+
+  // --- tier filter (applied before limit so ranks are global) ---
+  const tier = tierParam ? String(tierParam).toLowerCase() : null
+  const filtered = tier ? ranked.filter(e => e.severity_tier === tier) : ranked
+
+  // re-rank within the filtered set so rank 1 is still the worst shown
+  const reranked = filtered.map((e, idx) => ({ ...e, rank: idx + 1 }))
+
+  // --- limit ---
+  const result = limit !== null ? reranked.slice(0, limit) : reranked
+
+  res.json({
+    ranked: result,
+    total: result.length,
+    total_in_database: sorted.length,
+    ...(tier ? { filtered_by_tier: tier } : {}),
+    ...(limit !== null ? { limit } : {}),
+    note: 'Ranked from most terrible to least. The least terrible cheese on this list is still cheese.',
+  })
+})
+
+export default router

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import roastRouter from './routes/roast'
 import apiRouter from './routes/api'
 import verdictRouter from './routes/verdict'
 import compareRouter from './routes/compare'
+import worstRouter from './routes/worst'
 import { generateExplorerHtml } from './lib/explorerHtml'
 
 const app = express()
@@ -56,6 +57,7 @@ app.get('/', (req, res) => {
       'GET /verdict/:cheese':   'Get a structured condemnation: severity, smell, texture offense, closing statement',
       'GET /verdict':           'List all cheeses with known structured verdicts',
       'GET /compare':           'Compare two cheeses — declare which is worse across smell, texture, and cultural damage',
+      'GET /worst':             'All cheeses ranked from most to least terrible, with ?tier and ?limit filters',
       'GET /facts':             'Get a random damning cheese fact',
       'GET /facts/all':         'Get all facts unconditionally',
       'GET /roast':             'Get today\'s daily cheese roast — a different cheese condemned each day',
@@ -94,6 +96,9 @@ app.use('/verdict', verdictRouter)
 // GET /compare — structured head-to-head comparison of two cheeses
 app.use('/compare', compareRouter)
 
+// GET /worst — all cheeses ranked from most to least terrible
+app.use('/worst', worstRouter)
+
 // GET /api — endpoint discovery: all routes, parameters, and example responses
 app.use('/api', apiRouter)
 
@@ -112,6 +117,7 @@ app.use((_req, res) => {
       'GET /verdict',
       'GET /verdict/:cheese',
       'GET /compare',
+      'GET /worst',
       'GET /facts',
       'GET /facts/all',
       'GET /roast',

--- a/src/tests/worst.test.ts
+++ b/src/tests/worst.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for GET /worst.
+ *
+ * The least terrible cheese on this list is still cheese.
+ */
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import app from '../server'
+
+const REQUIRED_ENTRY_FIELDS = [
+  'rank',
+  'cheese',
+  'score',
+  'severity_tier',
+  'verdict',
+  'why_it_wins',
+] as const
+
+const VALID_TIERS = ['catastrophic', 'revolting', 'condemned'] as const
+
+// ── Basic shape ───────────────────────────────────────────────────────────────
+
+describe('GET /worst — response shape', () => {
+  it('returns 200', async () => {
+    const res = await request(app).get('/worst')
+    expect(res.status).toBe(200)
+  })
+
+  it('returns a ranked array', async () => {
+    const res = await request(app).get('/worst')
+    expect(Array.isArray(res.body.ranked)).toBe(true)
+  })
+
+  it('total matches ranked array length', async () => {
+    const res = await request(app).get('/worst')
+    expect(res.body.total).toBe(res.body.ranked.length)
+  })
+
+  it('total_in_database is present and positive', async () => {
+    const res = await request(app).get('/worst')
+    expect(typeof res.body.total_in_database).toBe('number')
+    expect(res.body.total_in_database).toBeGreaterThan(0)
+  })
+
+  it('note mentions "least terrible cheese on this list is still cheese"', async () => {
+    const res = await request(app).get('/worst')
+    expect(res.body.note).toMatch(/least terrible.*still cheese/i)
+  })
+
+  it('each entry has all required fields', async () => {
+    const res = await request(app).get('/worst')
+    for (const entry of res.body.ranked) {
+      for (const field of REQUIRED_ENTRY_FIELDS) {
+        expect(entry, `Missing field "${field}" in entry: ${entry.cheese}`).toHaveProperty(field)
+      }
+    }
+  })
+
+  it('each entry has a non-empty why_it_wins string', async () => {
+    const res = await request(app).get('/worst')
+    for (const entry of res.body.ranked) {
+      expect(typeof entry.why_it_wins).toBe('string')
+      expect(entry.why_it_wins.length, `Empty why_it_wins for ${entry.cheese}`).toBeGreaterThan(20)
+    }
+  })
+
+  it('each entry severity_tier is a valid tier', async () => {
+    const res = await request(app).get('/worst')
+    for (const entry of res.body.ranked) {
+      expect(
+        VALID_TIERS as readonly string[],
+        `Invalid tier "${entry.severity_tier}" for ${entry.cheese}`,
+      ).toContain(entry.severity_tier)
+    }
+  })
+})
+
+// ── Ranking correctness ───────────────────────────────────────────────────────
+
+describe('GET /worst — ranking order', () => {
+  it('cheeses are sorted ascending by score (most terrible first)', async () => {
+    const res = await request(app).get('/worst')
+    const scores: number[] = res.body.ranked.map((e: { score: number }) => e.score)
+    for (let i = 1; i < scores.length; i++) {
+      expect(scores[i]).toBeGreaterThanOrEqual(scores[i - 1])
+    }
+  })
+
+  it('rank 1 entry is casu martzu (score 0.125 — the worst of the worst)', async () => {
+    const res = await request(app).get('/worst')
+    const first = res.body.ranked[0]
+    expect(first.rank).toBe(1)
+    expect(first.cheese.toLowerCase()).toBe('casu martzu')
+    expect(first.score).toBe(0.125)
+    expect(first.severity_tier).toBe('catastrophic')
+  })
+
+  it('rank 1 entry has a why_it_wins mentioning maggots', async () => {
+    const res = await request(app).get('/worst')
+    expect(res.body.ranked[0].why_it_wins.toLowerCase()).toMatch(/maggot/)
+  })
+
+  it('gouda appears last (score 2.475 — the least terrible)', async () => {
+    const res = await request(app).get('/worst')
+    const last = res.body.ranked[res.body.ranked.length - 1]
+    expect(last.cheese.toLowerCase()).toBe('gouda')
+    expect(last.score).toBe(2.475)
+    expect(last.severity_tier).toBe('condemned')
+  })
+
+  it('ranks are sequential starting from 1', async () => {
+    const res = await request(app).get('/worst')
+    res.body.ranked.forEach((entry: { rank: number }, idx: number) => {
+      expect(entry.rank).toBe(idx + 1)
+    })
+  })
+})
+
+// ── ?limit param ──────────────────────────────────────────────────────────────
+
+describe('GET /worst?limit=N', () => {
+  it('?limit=1 returns exactly one entry', async () => {
+    const res = await request(app).get('/worst?limit=1')
+    expect(res.status).toBe(200)
+    expect(res.body.ranked).toHaveLength(1)
+    expect(res.body.total).toBe(1)
+  })
+
+  it('?limit=1 returns casu martzu', async () => {
+    const res = await request(app).get('/worst?limit=1')
+    expect(res.body.ranked[0].cheese.toLowerCase()).toBe('casu martzu')
+  })
+
+  it('?limit=3 returns exactly three entries', async () => {
+    const res = await request(app).get('/worst?limit=3')
+    expect(res.body.ranked).toHaveLength(3)
+    expect(res.body.total).toBe(3)
+  })
+
+  it('?limit=3 entry ranks are 1, 2, 3', async () => {
+    const res = await request(app).get('/worst?limit=3')
+    expect(res.body.ranked.map((e: { rank: number }) => e.rank)).toEqual([1, 2, 3])
+  })
+
+  it('response includes the limit field when ?limit is given', async () => {
+    const res = await request(app).get('/worst?limit=5')
+    expect(res.body.limit).toBe(5)
+  })
+
+  it('?limit=0 returns 400', async () => {
+    const res = await request(app).get('/worst?limit=0')
+    expect(res.status).toBe(400)
+  })
+
+  it('?limit=abc returns 400', async () => {
+    const res = await request(app).get('/worst?limit=abc')
+    expect(res.status).toBe(400)
+  })
+})
+
+// ── ?tier param ───────────────────────────────────────────────────────────────
+
+describe('GET /worst?tier=X', () => {
+  it('?tier=catastrophic returns only catastrophic entries', async () => {
+    const res = await request(app).get('/worst?tier=catastrophic')
+    expect(res.status).toBe(200)
+    for (const entry of res.body.ranked) {
+      expect(entry.severity_tier).toBe('catastrophic')
+    }
+  })
+
+  it('?tier=catastrophic returns 4 entries (scores < 1.0)', async () => {
+    const res = await request(app).get('/worst?tier=catastrophic')
+    expect(res.body.total).toBe(4)
+  })
+
+  it('?tier=catastrophic rank 1 is still casu martzu', async () => {
+    const res = await request(app).get('/worst?tier=catastrophic')
+    expect(res.body.ranked[0].cheese.toLowerCase()).toBe('casu martzu')
+  })
+
+  it('?tier=revolting returns only revolting entries', async () => {
+    const res = await request(app).get('/worst?tier=revolting')
+    expect(res.status).toBe(200)
+    for (const entry of res.body.ranked) {
+      expect(entry.severity_tier).toBe('revolting')
+    }
+  })
+
+  it('?tier=condemned returns only condemned entries', async () => {
+    const res = await request(app).get('/worst?tier=condemned')
+    expect(res.status).toBe(200)
+    for (const entry of res.body.ranked) {
+      expect(entry.severity_tier).toBe('condemned')
+    }
+  })
+
+  it('?tier=condemned last entry is gouda', async () => {
+    const res = await request(app).get('/worst?tier=condemned')
+    const entries = res.body.ranked
+    expect(entries[entries.length - 1].cheese.toLowerCase()).toBe('gouda')
+  })
+
+  it('response includes filtered_by_tier when ?tier is given', async () => {
+    const res = await request(app).get('/worst?tier=catastrophic')
+    expect(res.body.filtered_by_tier).toBe('catastrophic')
+  })
+
+  it('?tier=invalid returns 400 with valid_tiers hint', async () => {
+    const res = await request(app).get('/worst?tier=amazing')
+    expect(res.status).toBe(400)
+    expect(Array.isArray(res.body.valid_tiers)).toBe(true)
+  })
+
+  it('filtered ranks are re-numbered from 1', async () => {
+    const res = await request(app).get('/worst?tier=revolting')
+    res.body.ranked.forEach((entry: { rank: number }, idx: number) => {
+      expect(entry.rank).toBe(idx + 1)
+    })
+  })
+})
+
+// ── ?tier + ?limit combined ───────────────────────────────────────────────────
+
+describe('GET /worst — combined params', () => {
+  it('?tier=catastrophic&limit=2 returns 2 catastrophic entries', async () => {
+    const res = await request(app).get('/worst?tier=catastrophic&limit=2')
+    expect(res.status).toBe(200)
+    expect(res.body.ranked).toHaveLength(2)
+    for (const entry of res.body.ranked) {
+      expect(entry.severity_tier).toBe('catastrophic')
+    }
+  })
+
+  it('?tier=catastrophic&limit=2 rank 1 is still casu martzu', async () => {
+    const res = await request(app).get('/worst?tier=catastrophic&limit=2')
+    expect(res.body.ranked[0].cheese.toLowerCase()).toBe('casu martzu')
+  })
+
+  it('?limit larger than total returns all entries without error', async () => {
+    const res = await request(app).get('/worst?limit=9999')
+    expect(res.status).toBe(200)
+    expect(res.body.ranked.length).toBe(res.body.total_in_database)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `GET /worst` — all 21 rated cheeses ranked from most to least terrible, each annotated with a `severity_tier` and a `why_it_wins` field explaining the specific offense
- Supports `?tier=catastrophic|revolting|condemned` to filter by severity tier
- Supports `?limit=N` to return only the top N entries; both params can be combined
- Filtered results are re-ranked from 1 so the worst within the filtered set is always rank 1
- Returns 400 for invalid `tier` values or non-positive `limit` values

## Ranking

Sorted ascending by score (lower = more condemned). The three tiers map directly to the existing verdict labels in `cheese-ratings.json`:

| Tier | Score range | Count |
|---|---|---|
| `catastrophic` | < 1.0 | 4 cheeses (Casu Martzu, Blue Cheese, Stilton, Époisses) |
| `revolting` | 1.0–1.99 | 10 cheeses |
| `condemned` | 2.0+ | 7 cheeses |

## Example: `GET /worst?limit=1`

```json
{
  "ranked": [{
    "rank": 1,
    "cheese": "Casu Martzu",
    "score": 0.125,
    "severity_tier": "catastrophic",
    "verdict": "CATASTROPHIC",
    "why_it_wins": "Contains live maggots — cheese fly larvae deliberately left to eat through the interior and accelerate fermentation. Illegal to sell in the EU. Still consumed in Sardinia. This is what cheese becomes when you follow its awful logic without regulatory constraint."
  }],
  "total": 1,
  "total_in_database": 21,
  "limit": 1,
  "note": "Ranked from most terrible to least. The least terrible cheese on this list is still cheese."
}
```

## Schema drift

The schema-drift test from Issue #70 automatically validated `GET /worst` is present in `GET /api` — no manual schema sync required.

## Tests

- 331/331 passing
- 32 new assertions in `worst.test.ts` covering: response shape, ranking order, `?limit` (valid + invalid), `?tier` (all three tiers + invalid), combined params, and edge cases

Closes #84