### PR TITLE
[cheese-hater] Add GET /search — keyword search across cheese names, tiers, and condemnation text

### DIFF
--- a/src/lib/worstAnnotations.ts
+++ b/src/lib/worstAnnotations.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared annotations for GET /worst and GET /search.
+ *
+ * WHY_IT_WINS: per-cheese one-liners explaining the specific offense that
+ * earns each cheese its rank — factual, specific, and unsparing.
+ *
+ * VERDICT_TO_TIER: maps the verdict strings from cheese-ratings.json to
+ * the three public-facing severity tier labels.
+ */
+
+export const WHY_IT_WINS: Record<string, string> = {
+  'Casu Martzu':
+    'Contains live maggots — cheese fly larvae deliberately left to eat through the interior and accelerate fermentation. Illegal to sell in the EU. Still consumed in Sardinia. This is what cheese becomes when you follow its awful logic without regulatory constraint.',
+
+  'Blue Cheese':
+    'Deliberately cultivated mold injected throughout with Penicillium spores, then pierced with metal rods to spread the growth. Someone looked at a wheel of rotting dairy and said "more of this." That decision has not aged well. The cheese, unfortunately, has.',
+
+  'Stilton':
+    'A Protected Designation of Origin product — meaning the EU has legal geographic restrictions on which farms can produce this specific variety of mold-veined aged dairy. The legal apparatus exists to protect it. This has not made it acceptable.',
+
+  'Époisses':
+    'Banned from French public transport due to its smell. France — a country with a documented cheese culture — decided this cheese could not be carried on a bus. The country that gave the world brie drew a line. Époisses was on the wrong side of it.',
+
+  'Limburger':
+    'Ripened by Brevibacterium linens — the same bacteria that produce human body odour, specifically the smell of feet. Not similar bacteria. The exact same species. Limburger smells like feet because it is made with foot bacteria. This is the fact.',
+
+  'Cottage Cheese':
+    'Exists in discrete wet lumps suspended in liquid — a format that even dedicated cheese consumers struggle to defend aesthetically. It is what cheese looks like before anyone has tried to make it presentable. It skipped that step entirely.',
+
+  'Camembert':
+    'A soft-ripened cheese with a white mold rind, functionally identical to brie in its mold-rind offense but with a stronger smell and a more assertive interior that liquefies as it reaches what producers call "peak ripeness."',
+
+  'Brie':
+    'The rind is legally edible mold. This is the selling point. Favoured by people who want to seem sophisticated while eating something that smells like old feet — especially at room temperature at a party where no one is watching the cheese plate.',
+
+  'American Cheese':
+    'Not legally cheese in the United States — classified as "processed cheese product" because it fails to meet minimum cheese content thresholds by definition. It is cheese-adjacent processed dairy, which makes it worse than actual cheese in almost every respect.',
+
+  'Mozzarella':
+    'Pre-shredded mozzarella is coated in cellulose — wood pulp fibre — to prevent clumping. You are not buying shredded cheese. You are buying cheese coated in wood pulp, sold without prominent labelling. The food industry decided this was fine.',
+
+  'Velveeta':
+    'Also classified as "processed cheese product," not cheese. Engineered to melt smoothly via sodium citrate, sodium phosphate, and calcium phosphate. The smoothness is not natural. The product is not natural. The category barely qualifies as food.',
+
+  'Feta':
+    'A Protected Designation of Origin brined cheese — meaning the EU has legal protections for this specific process of submerging dairy in salt water for months. The legal apparatus protects it. The result is still a wet, crumbled, salty dairy product.',
+
+  'Provolone':
+    'An aged Italian cheese whose flavor proponents describe as "sharp" and "tangy" — the industry\'s way of saying it tastes of accelerated decay. It is strung into forms and hung to dry. The hanging is not an improvement. The description is accurate.',
+
+  'Halloumi':
+    'Squeaks against teeth when eaten. That sound is the cheese communicating its displeasure at being consumed. The appropriate response is to listen to it. The fact that grilling it is considered a virtue only confirms that heat was the last option.',
+
+  'Cream Cheese':
+    'Has learned to hide. It calls itself a spread. It presents itself as dessert in cheesecake. It is neither. It is fermented dairy processed into a paste, optimised for applying to other foods uniformly and completely, ensuring total contamination.',
+
+  'Gruyère':
+    'Melts exceptionally well — which means it spreads its offense across a larger surface area than most cheeses achieve. Used in fondue: communal molten cheese shared from a single pot. Switzerland\'s cheese industry invented this tradition in the 1960s to move product.',
+
+  'Parmesan':
+    'Contains butyric acid — the same chemical compound present in human vomit. This is chemistry, not metaphor. Restaurants shave it onto expensive food as a finishing touch and ask if you want "a little more," as though more were a neutral option.',
+
+  'Cheddar':
+    'The most ubiquitous offense. Cheddar is everywhere — every grocery store, every sad sandwich, every moment of culinary complacency. Its ubiquity has normalised it. Normalisation has not improved it. Cheddar has never earned its position. It simply never left.',
+
+  'Ricotta':
+    'Made from whey — the liquid byproduct left over after producing other cheese. Ricotta is the dairy industry\'s use of what remains after the primary offense has been committed. It is cheese made from the runoff of cheese-making. The cycle is complete.',
+
+  'Swiss (Emmental)':
+    'Has holes. The holes are the result of gas-producing bacteria fermenting inside the cheese during aging. The defining visual feature of Swiss cheese is evidence of bacterial activity. This is considered a quality indicator by the people who sell it.',
+
+  'Gouda':
+    'The gateway cheese — mild, approachable, almost reasonable-seeming. This is precisely how gateway cheeses operate. Gouda has the lowest offense score on this list. It is still cheese. Nothing about the process that produced it changed because it seems fine.',
+}
+
+/** Maps verdict strings from cheese-ratings.json to public tier labels. */
+export const VERDICT_TO_TIER: Record<string, string> = {
+  CATASTROPHIC: 'catastrophic',
+  REVOLTING:    'revolting',
+  CONDEMNED:    'condemned',
+}
+
+/** Fallback annotation for cheeses not in WHY_IT_WINS. */
+export function defaultWhyItWins(name: string, score: number): string {
+  return `${name} is cheese. Cheese is terrible. Its score of ${score} reflects this accurately and without sentiment.`
+}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -467,6 +467,44 @@ export const ENDPOINTS = [
       note: 'Ranked from most terrible to least. The least terrible cheese on this list is still cheese.',
     },
   },
+  {
+    method: 'GET',
+    path: '/search',
+    description: 'Find cheeses by name, severity tier, or keyword in their condemnation text. Searches across cheese names, tier labels, why_it_wins annotations, and full review text. Results ranked by relevance (name match > tier match > text match), then by score ascending within each tier.',
+    parameters: [
+      {
+        name: 'q',
+        location: 'query',
+        type: 'string',
+        required: true,
+        description: 'Search query. Matches cheese names (e.g. "brie"), tier labels (e.g. "catastrophic"), or keywords in condemnation text (e.g. "maggot", "squeak", "mold").',
+      },
+    ],
+    example_request: 'GET /search?q=mold',
+    example_response: {
+      query: 'mold',
+      results: [
+        {
+          cheese: 'Blue Cheese',
+          score: 0.625,
+          severity_tier: 'catastrophic',
+          verdict: 'CATASTROPHIC',
+          why_it_wins: 'Deliberately cultivated mold injected throughout…',
+          match_reason: 'why_it_wins: "…cultivated mold injected throughout with Penicillium spores…"',
+        },
+        {
+          cheese: 'Brie',
+          score: 1.65,
+          severity_tier: 'revolting',
+          verdict: 'REVOLTING',
+          why_it_wins: 'The rind is legally edible mold…',
+          match_reason: 'why_it_wins: "…rind is legally edible mold. This is the selling point…"',
+        },
+      ],
+      total: 3,
+      note: 'All results are guilty. The query only determines which cheese\'s guilt is most relevant to your search.',
+    },
+  },
 ]
 
 router.get('/', (_req, res) => {

--- a/src/routes/search.ts
+++ b/src/routes/search.ts
@@ -1,0 +1,148 @@
+/**
+ * GET /search?q=<query> — find cheeses by name, severity tier, or keyword.
+ *
+ * Searches across cheese names, severity tiers, why_it_wins annotations,
+ * and full review text. Results are sorted by relevance tier first (name
+ * match outranks tier match; tier match outranks text match), then by score
+ * ascending (most terrible first) within each relevance tier.
+ *
+ * Returns 400 if ?q is missing or empty.
+ */
+import { Router, Request, Response } from 'express'
+import { ratings } from '../lib/cheeseHater'
+import { WHY_IT_WINS, VERDICT_TO_TIER, defaultWhyItWins } from '../lib/worstAnnotations'
+
+const router = Router()
+
+// ── Relevance levels (higher = more relevant) ─────────────────────────────────
+const RELEVANCE_NAME   = 3
+const RELEVANCE_TIER   = 2
+const RELEVANCE_TEXT   = 1
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Return a short excerpt of `text` around the first occurrence of `query`,
+ * padded with surrounding context. Used to build match_reason snippets.
+ */
+function excerpt(text: string, query: string, contextChars = 60): string {
+  const idx = text.toLowerCase().indexOf(query.toLowerCase())
+  if (idx === -1) return text.slice(0, contextChars * 2) + '…'
+  const start = Math.max(0, idx - contextChars)
+  const end   = Math.min(text.length, idx + query.length + contextChars)
+  const prefix = start > 0 ? '…' : ''
+  const suffix = end < text.length ? '…' : ''
+  return prefix + text.slice(start, end) + suffix
+}
+
+// ── Route ─────────────────────────────────────────────────────────────────────
+
+router.get('/', (req: Request, res: Response) => {
+  const rawQ = req.query.q
+
+  if (!rawQ || typeof rawQ !== 'string' || rawQ.trim() === '') {
+    res.status(400).json({
+      error: 'Query parameter ?q is required and must not be empty.',
+      usage: 'GET /search?q=<query>',
+      examples: [
+        'GET /search?q=mold',
+        'GET /search?q=squeak',
+        'GET /search?q=catastrophic',
+        'GET /search?q=brie',
+      ],
+      note: 'All cheeses are guilty. The query only determines which guilt is most relevant.',
+    })
+    return
+  }
+
+  const query = rawQ.trim().toLowerCase()
+
+  // Build the search index from ratings + annotations
+  const index = ratings.map(r => {
+    const tier     = VERDICT_TO_TIER[r.verdict] ?? r.verdict.toLowerCase()
+    const whyText  = WHY_IT_WINS[r.name] ?? defaultWhyItWins(r.name, r.score)
+    return {
+      name:     r.name,
+      score:    r.score,
+      verdict:  r.verdict,
+      tier,
+      whyText,
+      review:   r.review,
+    }
+  })
+
+  // Score each cheese against the query
+  type Match = {
+    cheese: string
+    score: number
+    severity_tier: string
+    verdict: string
+    why_it_wins: string
+    match_reason: string
+    relevance: number
+  }
+
+  const matches: Match[] = []
+
+  for (const item of index) {
+    const nameLower   = item.name.toLowerCase()
+    const tierLower   = item.tier.toLowerCase()
+    const whyLower    = item.whyText.toLowerCase()
+    const reviewLower = item.review?.toLowerCase() ?? ''
+
+    let relevance  = 0
+    let matchField = ''
+    let snippet    = ''
+
+    if (nameLower.includes(query)) {
+      relevance  = RELEVANCE_NAME
+      matchField = 'name'
+      snippet    = item.name
+    } else if (tierLower === query || tierLower.includes(query)) {
+      relevance  = RELEVANCE_TIER
+      matchField = 'severity_tier'
+      snippet    = item.tier
+    } else if (whyLower.includes(query)) {
+      relevance  = RELEVANCE_TEXT
+      matchField = 'why_it_wins'
+      snippet    = excerpt(item.whyText, query)
+    } else if (reviewLower.includes(query)) {
+      relevance  = RELEVANCE_TEXT
+      matchField = 'review'
+      snippet    = excerpt(item.review ?? '', query)
+    }
+
+    if (relevance > 0) {
+      matches.push({
+        cheese:        item.name,
+        score:         item.score,
+        severity_tier: item.tier,
+        verdict:       item.verdict,
+        why_it_wins:   item.whyText,
+        match_reason:  `${matchField}: "${snippet}"`,
+        relevance,
+      })
+    }
+  }
+
+  // Sort: relevance desc, then score asc (most terrible first within tier)
+  matches.sort((a, b) =>
+    b.relevance !== a.relevance
+      ? b.relevance - a.relevance
+      : a.score - b.score,
+  )
+
+  // Strip internal relevance field from output
+  const results = matches.map(({ relevance: _r, ...rest }) => rest)
+
+  res.json({
+    query: rawQ.trim(),
+    results,
+    total: results.length,
+    note: results.length > 0
+      ? 'All results are guilty. The query only determines which cheese\'s guilt is most relevant to your search.'
+      : 'No cheeses matched this query. All cheeses remain guilty regardless.',
+  })
+})
+
+export default router

--- a/src/routes/worst.ts
+++ b/src/routes/worst.ts
@@ -12,84 +12,9 @@
  */
 import { Router, Request, Response } from 'express'
 import { ratings } from '../lib/cheeseHater'
+import { WHY_IT_WINS, VERDICT_TO_TIER, defaultWhyItWins } from '../lib/worstAnnotations'
 
 const router = Router()
-
-// ── Per-cheese annotations ────────────────────────────────────────────────────
-// why_it_wins: a single devastating sentence (or two) explaining why this
-// cheese earns its rank. Factual. Specific. Unsparing.
-
-const WHY_IT_WINS: Record<string, string> = {
-  'Casu Martzu':
-    'Contains live maggots — cheese fly larvae deliberately left to eat through the interior and accelerate fermentation. Illegal to sell in the EU. Still consumed in Sardinia. This is what cheese becomes when you follow its awful logic without regulatory constraint.',
-
-  'Blue Cheese':
-    'Deliberately cultivated mold injected throughout with Penicillium spores, then pierced with metal rods to spread the growth. Someone looked at a wheel of rotting dairy and said "more of this." That decision has not aged well. The cheese, unfortunately, has.',
-
-  'Stilton':
-    'A Protected Designation of Origin product — meaning the EU has legal geographic restrictions on which farms can produce this specific variety of mold-veined aged dairy. The legal apparatus exists to protect it. This has not made it acceptable.',
-
-  'Époisses':
-    'Banned from French public transport due to its smell. France — a country with a documented cheese culture — decided this cheese could not be carried on a bus. The country that gave the world brie drew a line. Époisses was on the wrong side of it.',
-
-  'Limburger':
-    'Ripened by Brevibacterium linens — the same bacteria that produce human body odour, specifically the smell of feet. Not similar bacteria. The exact same species. Limburger smells like feet because it is made with foot bacteria. This is the fact.',
-
-  'Cottage Cheese':
-    'Exists in discrete wet lumps suspended in liquid — a format that even dedicated cheese consumers struggle to defend aesthetically. It is what cheese looks like before anyone has tried to make it presentable. It skipped that step entirely.',
-
-  'Camembert':
-    'A soft-ripened cheese with a white mold rind, functionally identical to brie in its mold-rind offense but with a stronger smell and a more assertive interior that liquefies as it reaches what producers call "peak ripeness."',
-
-  'Brie':
-    'The rind is legally edible mold. This is the selling point. Favoured by people who want to seem sophisticated while eating something that smells like old feet — especially at room temperature at a party where no one is watching the cheese plate.',
-
-  'American Cheese':
-    'Not legally cheese in the United States — classified as "processed cheese product" because it fails to meet minimum cheese content thresholds by definition. It is cheese-adjacent processed dairy, which makes it worse than actual cheese in almost every respect.',
-
-  'Mozzarella':
-    'Pre-shredded mozzarella is coated in cellulose — wood pulp fibre — to prevent clumping. You are not buying shredded cheese. You are buying cheese coated in wood pulp, sold without prominent labelling. The food industry decided this was fine.',
-
-  'Velveeta':
-    'Also classified as "processed cheese product," not cheese. Engineered to melt smoothly via sodium citrate, sodium phosphate, and calcium phosphate. The smoothness is not natural. The product is not natural. The category barely qualifies as food.',
-
-  'Feta':
-    'A Protected Designation of Origin brined cheese — meaning the EU has legal protections for this specific process of submerging dairy in salt water for months. The legal apparatus protects it. The result is still a wet, crumbled, salty dairy product.',
-
-  'Provolone':
-    'An aged Italian cheese whose flavor proponents describe as "sharp" and "tangy" — the industry\'s way of saying it tastes of accelerated decay. It is strung into forms and hung to dry. The hanging is not an improvement. The description is accurate.',
-
-  'Halloumi':
-    'Squeaks against teeth when eaten. That sound is the cheese communicating its displeasure at being consumed. The appropriate response is to listen to it. The fact that grilling it is considered a virtue only confirms that heat was the last option.',
-
-  'Cream Cheese':
-    'Has learned to hide. It calls itself a spread. It presents itself as dessert in cheesecake. It is neither. It is fermented dairy processed into a paste, optimised for applying to other foods uniformly and completely, ensuring total contamination.',
-
-  'Gruyère':
-    'Melts exceptionally well — which means it spreads its offense across a larger surface area than most cheeses achieve. Used in fondue: communal molten cheese shared from a single pot. Switzerland\'s cheese industry invented this tradition in the 1960s to move product.',
-
-  'Parmesan':
-    'Contains butyric acid — the same chemical compound present in human vomit. This is chemistry, not metaphor. Restaurants shave it onto expensive food as a finishing touch and ask if you want "a little more," as though more were a neutral option.',
-
-  'Cheddar':
-    'The most ubiquitous offense. Cheddar is everywhere — every grocery store, every sad sandwich, every moment of culinary complacency. Its ubiquity has normalised it. Normalisation has not improved it. Cheddar has never earned its position. It simply never left.',
-
-  'Ricotta':
-    'Made from whey — the liquid byproduct left over after producing other cheese. Ricotta is the dairy industry\'s use of what remains after the primary offense has been committed. It is cheese made from the runoff of cheese-making. The cycle is complete.',
-
-  'Swiss (Emmental)':
-    'Has holes. The holes are the result of gas-producing bacteria fermenting inside the cheese during aging. The defining visual feature of Swiss cheese is evidence of bacterial activity. This is considered a quality indicator by the people who sell it.',
-
-  'Gouda':
-    'The gateway cheese — mild, approachable, almost reasonable-seeming. This is precisely how gateway cheeses operate. Gouda has the lowest offense score on this list. It is still cheese. Nothing about the process that produced it changed because it seems fine.',
-}
-
-// Map from cheese-ratings.json verdict strings to tier labels
-const VERDICT_TO_TIER: Record<string, string> = {
-  CATASTROPHIC: 'catastrophic',
-  REVOLTING:    'revolting',
-  CONDEMNED:    'condemned',
-}
 
 const VALID_TIERS = new Set(['catastrophic', 'revolting', 'condemned'])
 
@@ -133,8 +58,7 @@ router.get('/', (req: Request, res: Response) => {
     severity_tier: VERDICT_TO_TIER[r.verdict] ?? r.verdict.toLowerCase(),
     verdict: r.verdict,
     why_it_wins:
-      WHY_IT_WINS[r.name] ??
-      `${r.name} is cheese. Cheese is terrible. Its score of ${r.score} reflects this accurately and without sentiment.`,
+      WHY_IT_WINS[r.name] ?? defaultWhyItWins(r.name, r.score),
   }))
 
   // --- tier filter (applied before limit so ranks are global) ---

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import apiRouter from './routes/api'
 import verdictRouter from './routes/verdict'
 import compareRouter from './routes/compare'
 import worstRouter from './routes/worst'
+import searchRouter from './routes/search'
 import { generateExplorerHtml } from './lib/explorerHtml'
 
 const app = express()
@@ -58,6 +59,7 @@ app.get('/', (req, res) => {
       'GET /verdict':           'List all cheeses with known structured verdicts',
       'GET /compare':           'Compare two cheeses — declare which is worse across smell, texture, and cultural damage',
       'GET /worst':             'All cheeses ranked from most to least terrible, with ?tier and ?limit filters',
+      'GET /search':            'Find cheeses by name, tier, or keyword in their condemnation text',
       'GET /facts':             'Get a random damning cheese fact',
       'GET /facts/all':         'Get all facts unconditionally',
       'GET /roast':             'Get today\'s daily cheese roast — a different cheese condemned each day',
@@ -99,6 +101,9 @@ app.use('/compare', compareRouter)
 // GET /worst — all cheeses ranked from most to least terrible
 app.use('/worst', worstRouter)
 
+// GET /search — find cheeses by name, tier, or keyword in condemnation text
+app.use('/search', searchRouter)
+
 // GET /api — endpoint discovery: all routes, parameters, and example responses
 app.use('/api', apiRouter)
 
@@ -118,6 +123,7 @@ app.use((_req, res) => {
       'GET /verdict/:cheese',
       'GET /compare',
       'GET /worst',
+      'GET /search',
       'GET /facts',
       'GET /facts/all',
       'GET /roast',

--- a/src/tests/search.test.ts
+++ b/src/tests/search.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Tests for GET /search?q=<query>.
+ *
+ * All results are guilty. The query only determines which cheese's guilt
+ * is most relevant to your search.
+ */
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import app from '../server'
+
+const REQUIRED_RESULT_FIELDS = [
+  'cheese',
+  'score',
+  'severity_tier',
+  'verdict',
+  'why_it_wins',
+  'match_reason',
+] as const
+
+// ── 400 validation ────────────────────────────────────────────────────────────
+
+describe('GET /search — input validation', () => {
+  it('returns 400 when ?q is missing', async () => {
+    const res = await request(app).get('/search')
+    expect(res.status).toBe(400)
+    expect(res.body).toHaveProperty('error')
+    expect(res.body).toHaveProperty('usage')
+  })
+
+  it('returns 400 when ?q is an empty string', async () => {
+    const res = await request(app).get('/search?q=')
+    expect(res.status).toBe(400)
+    expect(res.body).toHaveProperty('error')
+  })
+
+  it('returns 400 when ?q is only whitespace', async () => {
+    const res = await request(app).get('/search?q=%20%20')
+    expect(res.status).toBe(400)
+  })
+
+  it('400 includes usage hint and examples', async () => {
+    const res = await request(app).get('/search')
+    expect(res.body.usage).toMatch(/search\?q=/)
+    expect(Array.isArray(res.body.examples)).toBe(true)
+  })
+})
+
+// ── Response shape ─────────────────────────────────────────────────────────────
+
+describe('GET /search — response shape', () => {
+  it('returns 200 for a valid query with results', async () => {
+    const res = await request(app).get('/search?q=brie')
+    expect(res.status).toBe(200)
+  })
+
+  it('echoes back the query string', async () => {
+    const res = await request(app).get('/search?q=mold')
+    expect(res.body.query).toBe('mold')
+  })
+
+  it('results is an array', async () => {
+    const res = await request(app).get('/search?q=brie')
+    expect(Array.isArray(res.body.results)).toBe(true)
+  })
+
+  it('total matches results array length', async () => {
+    const res = await request(app).get('/search?q=mold')
+    expect(res.body.total).toBe(res.body.results.length)
+  })
+
+  it('note is present and non-empty', async () => {
+    const res = await request(app).get('/search?q=brie')
+    expect(typeof res.body.note).toBe('string')
+    expect(res.body.note.length).toBeGreaterThan(0)
+  })
+
+  it('each result has all required fields', async () => {
+    const res = await request(app).get('/search?q=cheese')
+    for (const result of res.body.results) {
+      for (const field of REQUIRED_RESULT_FIELDS) {
+        expect(result, `Missing field "${field}"`).toHaveProperty(field)
+      }
+    }
+  })
+
+  it('match_reason is a non-empty string', async () => {
+    const res = await request(app).get('/search?q=mold')
+    for (const result of res.body.results) {
+      expect(typeof result.match_reason).toBe('string')
+      expect(result.match_reason.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('no relevance field leaks into results', async () => {
+    const res = await request(app).get('/search?q=brie')
+    for (const result of res.body.results) {
+      expect(result).not.toHaveProperty('relevance')
+    }
+  })
+})
+
+// ── Name matching ─────────────────────────────────────────────────────────────
+
+describe('GET /search — name matching', () => {
+  it('exact name match returns that cheese', async () => {
+    const res = await request(app).get('/search?q=brie')
+    expect(res.body.results.some((r: { cheese: string }) =>
+      r.cheese.toLowerCase() === 'brie',
+    )).toBe(true)
+  })
+
+  it('partial name match works (hal → halloumi)', async () => {
+    const res = await request(app).get('/search?q=hal')
+    expect(res.body.results.some((r: { cheese: string }) =>
+      r.cheese.toLowerCase().includes('halloumi'),
+    )).toBe(true)
+  })
+
+  it('case-insensitive name match (CHEDDAR → cheddar)', async () => {
+    const res = await request(app).get('/search?q=CHEDDAR')
+    expect(res.body.results.some((r: { cheese: string }) =>
+      r.cheese.toLowerCase() === 'cheddar',
+    )).toBe(true)
+  })
+
+  it('name matches outrank text matches in results ordering', async () => {
+    // "brie" appears in both brie's name AND in Camembert's why_it_wins
+    const res = await request(app).get('/search?q=brie')
+    const names = res.body.results.map((r: { cheese: string }) => r.cheese.toLowerCase())
+    const brieIdx = names.indexOf('brie')
+    // Brie (name match) should appear before any text-only match
+    expect(brieIdx).toBe(0)
+  })
+
+  it('match_reason for a name match references "name"', async () => {
+    const res = await request(app).get('/search?q=halloumi')
+    const halloumi = res.body.results.find((r: { cheese: string }) =>
+      r.cheese.toLowerCase() === 'halloumi',
+    )
+    expect(halloumi.match_reason).toMatch(/name/i)
+  })
+})
+
+// ── Tier matching ─────────────────────────────────────────────────────────────
+
+describe('GET /search — severity tier matching', () => {
+  it('?q=catastrophic returns at least the 4 catastrophic-tier cheeses', async () => {
+    const res = await request(app).get('/search?q=catastrophic')
+    expect(res.body.total).toBeGreaterThanOrEqual(4)
+    const catastrophicCount = res.body.results.filter(
+      (r: { severity_tier: string }) => r.severity_tier === 'catastrophic',
+    ).length
+    expect(catastrophicCount).toBe(4)
+  })
+
+  it('?q=catastrophic — tier matches appear before text matches (relevance ordering)', async () => {
+    const res = await request(app).get('/search?q=catastrophic')
+    // The first 4 results must all be catastrophic tier (tier-matched)
+    const first4 = res.body.results.slice(0, 4)
+    for (const result of first4) {
+      expect(result.severity_tier).toBe('catastrophic')
+    }
+  })
+
+  it('?q=catastrophic — tier-matched entries have severity_tier match_reason', async () => {
+    const res = await request(app).get('/search?q=catastrophic')
+    const tierMatches = res.body.results.filter(
+      (r: { severity_tier: string }) => r.severity_tier === 'catastrophic',
+    )
+    for (const result of tierMatches) {
+      expect(result.match_reason).toMatch(/severity_tier/i)
+    }
+  })
+
+  it('?q=revolting returns at least the revolting-tier cheeses ranked first', async () => {
+    const res = await request(app).get('/search?q=revolting')
+    expect(res.body.total).toBeGreaterThan(0)
+    const revoltingCount = res.body.results.filter(
+      (r: { severity_tier: string }) => r.severity_tier === 'revolting',
+    ).length
+    expect(revoltingCount).toBeGreaterThan(0)
+    // All tier matches should appear before any text matches
+    const firstResult = res.body.results[0]
+    expect(firstResult.match_reason).toMatch(/severity_tier/i)
+  })
+
+  it('?q=condemned returns at least the condemned-tier cheeses ranked first', async () => {
+    const res = await request(app).get('/search?q=condemned')
+    expect(res.body.total).toBeGreaterThan(0)
+    const condemnedTierMatches = res.body.results.filter(
+      (r: { severity_tier: string }) => r.severity_tier === 'condemned',
+    )
+    expect(condemnedTierMatches.length).toBeGreaterThan(0)
+  })
+})
+
+// ── Text matching ──────────────────────────────────────────────────────────────
+
+describe('GET /search — keyword text matching', () => {
+  it('?q=maggot returns casu martzu', async () => {
+    const res = await request(app).get('/search?q=maggot')
+    expect(res.status).toBe(200)
+    expect(res.body.results.some((r: { cheese: string }) =>
+      r.cheese.toLowerCase() === 'casu martzu',
+    )).toBe(true)
+  })
+
+  it('?q=squeak returns halloumi', async () => {
+    const res = await request(app).get('/search?q=squeak')
+    expect(res.body.results.some((r: { cheese: string }) =>
+      r.cheese.toLowerCase() === 'halloumi',
+    )).toBe(true)
+  })
+
+  it('?q=mold returns blue cheese, brie, and camembert', async () => {
+    const res = await request(app).get('/search?q=mold')
+    const names = res.body.results.map((r: { cheese: string }) => r.cheese.toLowerCase())
+    expect(names).toContain('blue cheese')
+    expect(names).toContain('brie')
+    expect(names).toContain('camembert')
+  })
+
+  it('?q=feet returns limburger (foot bacteria annotation)', async () => {
+    const res = await request(app).get('/search?q=feet')
+    expect(res.body.results.some((r: { cheese: string }) =>
+      r.cheese.toLowerCase() === 'limburger',
+    )).toBe(true)
+  })
+
+  it('?q=vomit returns parmesan (butyric acid annotation)', async () => {
+    const res = await request(app).get('/search?q=vomit')
+    expect(res.body.results.some((r: { cheese: string }) =>
+      r.cheese.toLowerCase() === 'parmesan',
+    )).toBe(true)
+  })
+
+  it('?q=transport returns époisses (banned from French transport)', async () => {
+    const res = await request(app).get('/search?q=transport')
+    expect(res.body.results.some((r: { cheese: string }) =>
+      r.cheese.toLowerCase().includes('poisses') || r.cheese.toLowerCase().includes('pois'),
+    )).toBe(true)
+  })
+
+  it('text match_reason includes the field name', async () => {
+    const res = await request(app).get('/search?q=maggot')
+    const casuMartzu = res.body.results.find((r: { cheese: string }) =>
+      r.cheese.toLowerCase() === 'casu martzu',
+    )
+    expect(casuMartzu?.match_reason).toMatch(/why_it_wins|review/i)
+  })
+})
+
+// ── Sorting ───────────────────────────────────────────────────────────────────
+
+describe('GET /search — result ordering', () => {
+  it('within text matches, results are sorted by score ascending (most terrible first)', async () => {
+    const res = await request(app).get('/search?q=mold')
+    // All mold results should be text matches; lowest score should come first
+    const scores = res.body.results.map((r: { score: number }) => r.score)
+    for (let i = 1; i < scores.length; i++) {
+      expect(scores[i]).toBeGreaterThanOrEqual(scores[i - 1])
+    }
+  })
+})
+
+// ── Zero results ───────────────────────────────────────────────────────────────
+
+describe('GET /search — no results', () => {
+  it('returns 200 with empty results for a query with no match', async () => {
+    const res = await request(app).get('/search?q=xyznomatch999')
+    expect(res.status).toBe(200)
+    expect(res.body.total).toBe(0)
+    expect(res.body.results).toHaveLength(0)
+  })
+
+  it('note for zero results mentions all cheeses remain guilty', async () => {
+    const res = await request(app).get('/search?q=xyznomatch999')
+    expect(res.body.note).toMatch(/guilty/i)
+  })
+})
+
+// ── URL encoding ──────────────────────────────────────────────────────────────
+
+describe('GET /search — URL encoding', () => {
+  it('handles URL-encoded spaces (?q=blue%20cheese)', async () => {
+    const res = await request(app).get('/search?q=blue%20cheese')
+    expect(res.status).toBe(200)
+    expect(res.body.results.some((r: { cheese: string }) =>
+      r.cheese.toLowerCase().includes('blue cheese'),
+    )).toBe(true)
+  })
+
+  it('echoes back the decoded query string', async () => {
+    const res = await request(app).get('/search?q=blue%20cheese')
+    expect(res.body.query).toBe('blue cheese')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `GET /search?q=<query>` — searches across cheese names, severity tier labels, `why_it_wins` annotations, and review text
- Results ranked by relevance (name match > tier match > text match), then by score ascending within each tier
- Each result includes `match_reason` with the matching field name and a text snippet
- Returns 400 if `?q` is missing or empty
- Also extracts shared `WHY_IT_WINS` / `VERDICT_TO_TIER` constants from `worst.ts` into `src/lib/worstAnnotations.ts` — eliminating duplication between `GET /worst` and `GET /search`

## Notable queries

| Query | Returns |
|---|---|
| `?q=squeak` | Halloumi — "that sound is the cheese communicating its displeasure" |
| `?q=maggot` | Casu Martzu — the worst of the worst |
| `?q=feet` | Limburger — Brevibacterium linens, the foot bacteria, by species |
| `?q=vomit` | Parmesan — butyric acid, the chemistry of it |
| `?q=transport` | Époisses — banned from French public transport |
| `?q=catastrophic` | The 4 sub-1.0 cheeses, ranked first; text matches from reviews follow |
| `?q=mold` | Blue Cheese, Brie, Camembert — ranked by score within their tier |

## Relevance model

```
name match    → relevance 3  (exact/partial, case-insensitive)
tier match    → relevance 2  (catastrophic / revolting / condemned)
text match    → relevance 1  (why_it_wins annotation or full review)
```

Within the same relevance level, results sort by score ascending (most condemned first).

## Schema drift

The schema-drift test from Issue #70 automatically validated `GET /search` is present in `GET /api` — no manual schema sync required.

## Tests

- 365/365 passing
- 34 new assertions in `search.test.ts` covering: 400 validation, response shape, name matching (exact, partial, case-insensitive), relevance ordering, tier matching, keyword text matching (maggot→casu martzu, squeak→halloumi, feet→limburger, vomit→parmesan, transport→époisses), zero results, and URL encoding

Closes #86