### PR TITLE
[cheese-hater] Add GET /etymology/:cheese — cheese name origins and why they don't help

### DIFF
--- a/src/data/cheese-etymologies.json
+++ b/src/data/cheese-etymologies.json
@@ -1,0 +1,112 @@
+[
+  {
+    "cheese": "parmesan",
+    "aliases": ["parmigiano", "parmigiano-reggiano"],
+    "origin_language": "Italian",
+    "origin_word": "Parmigiano",
+    "meaning": "Of Parma — the city in Emilia-Romagna, Italy",
+    "story": "Named after the city of Parma, where this aged abomination has been produced since at least the 13th century. The full name Parmigiano-Reggiano denotes the provinces of Parma and Reggio Emilia — two regions that apparently decided their greatest contribution to history would be a wheel of hardened dairy product that smells unmistakably of vomit. The name is protected by EU law, which means even the designation of this offense is legally enforced.",
+    "first_recorded": "c. 1254 CE",
+    "does_this_help": false,
+    "why_not": "Knowing that a city willingly named itself after this cheese does not rehabilitate the cheese. It raises serious questions about the city."
+  },
+  {
+    "cheese": "brie",
+    "aliases": ["brie de meaux", "brie de melun"],
+    "origin_language": "French",
+    "origin_word": "Brie",
+    "meaning": "From the Brie region of northern France, in the Seine-et-Marne department",
+    "story": "Named after the Brie plateau, a historical agricultural region east of Paris. The name itself likely derives from a pre-Roman Gaulish root. Charlemagne reportedly tasted it in 774 CE and declared it one of the most delicious foods he had ever eaten — a judgment that tells you something about 8th-century Frankish cuisine, and nothing good about cheese. The rind is edible mold. The etymology is irrelevant.",
+    "first_recorded": "c. 774 CE (Carolingian chronicles)",
+    "does_this_help": false,
+    "why_not": "The fact that a Holy Roman Emperor enjoyed this mold-rind dairy product in the Dark Ages is not a recommendation. It is a historical warning."
+  },
+  {
+    "cheese": "cheddar",
+    "aliases": [],
+    "origin_language": "Old English",
+    "origin_word": "Ceodre",
+    "meaning": "Possibly 'pouch' or 'bag', referring to the gorge or a descriptive term for the landscape of Cheddar, Somerset",
+    "story": "Named after the village of Cheddar in Somerset, England, where the cheese has been produced since at least the 12th century. The village itself likely takes its name from Old English 'ceodre', possibly meaning a pouch-like valley — a reference to Cheddar Gorge. Records from 1170 show King Henry II purchased 10,240 lbs of Cheddar cheese, establishing a royal precedent for terrible decisions. The 'cheddaring' process — where curds are stacked and turned to expel whey — takes its name from the cheese, not the other way around.",
+    "first_recorded": "c. 1170 CE",
+    "does_this_help": false,
+    "why_not": "Learning that an entire geological formation and production process are named after this ubiquitous offense does not diminish the offense. It magnifies it."
+  },
+  {
+    "cheese": "gouda",
+    "aliases": ["goudse kaas"],
+    "origin_language": "Dutch",
+    "origin_word": "Gouda",
+    "meaning": "The city of Gouda in South Holland, Netherlands — itself named from a Germanic root possibly meaning 'good' or relating to a local family name",
+    "story": "Named after the city of Gouda, which served as the regional trading center where this cheese was historically sold — not necessarily where it was made. The city's cheese market, established in the Middle Ages, became one of the largest in the world. Gouda cheese thus takes its name from a marketplace rather than an origin, which is fitting: it is fundamentally a commercial product masquerading as a culinary experience. 'Goudse kaas' simply means 'Gouda's cheese' in Dutch.",
+    "first_recorded": "c. 1184 CE",
+    "does_this_help": false,
+    "why_not": "A cheese named after its market rather than its maker tells you everything about its priorities. It was always more about commerce than quality. The etymology confirms this."
+  },
+  {
+    "cheese": "gruyère",
+    "aliases": ["gruyere"],
+    "origin_language": "French/Old High German",
+    "origin_word": "Gruyères",
+    "meaning": "The town of Gruyères in the Fribourg canton of Switzerland — the town name likely derives from Old High German 'gruoiari', meaning a forest warden or one who manages woodland",
+    "story": "Named after the medieval town of Gruyères, whose name may trace to a Germanic word for a forest administrator — a gruyère was someone who managed the lord's forests. The town's counts held authority over the surrounding alpine region from the 10th century. The cheese was first mentioned in records around 1115 CE. Today it is prized for its melting properties, which means its primary virtue is the ability to spread its offense across a larger surface area. Fondue is its highest achievement and most damning legacy.",
+    "first_recorded": "c. 1115 CE",
+    "does_this_help": false,
+    "why_not": "Discovering that this cheese is named after medieval forest bureaucrats only reinforces the impression that it exists through institutional inertia rather than merit."
+  },
+  {
+    "cheese": "halloumi",
+    "aliases": ["haloumi", "hellim"],
+    "origin_language": "Cypriot Greek / Arabic",
+    "origin_word": "χαλλούμι (challoumi) / حلوم (hallum)",
+    "meaning": "Debated: possibly from Arabic 'hallum' (to be mild or gentle) or Coptic 'halum' (cheese). Neither etymology makes the squeaking forgivable.",
+    "story": "The etymology of halloumi is genuinely contested. One theory traces it to the Arabic 'hallum', meaning mild or sweet. Another proposes a Coptic origin from 'halum' or 'hlom', a general term for cheese. It appears in Cypriot records from the Byzantine period and became central to Cypriot culinary identity. The cheese is notable for its high melting point, which allows it to be grilled or fried — and for the unmistakable squeaking sound it makes against teeth, which is the cheese's only form of self-expression, and it is a cry for help.",
+    "first_recorded": "c. 7th century CE (Byzantine Cyprus)",
+    "does_this_help": false,
+    "why_not": "Whether the name means 'mild' in Arabic or 'cheese' in Coptic, neither origin explains or excuses the squeaking. The sound remains an affront regardless of etymology."
+  },
+  {
+    "cheese": "mozzarella",
+    "aliases": ["fresh mozzarella", "mozzarella di bufala", "fior di latte"],
+    "origin_language": "Italian",
+    "origin_word": "mozzare",
+    "meaning": "To cut off, to lop — from the practice of cutting or pinching the curd during production",
+    "story": "Mozzarella derives from the Italian verb 'mozzare', meaning to cut off or sever — a reference to the traditional production method in which a cheesemaker cuts or pinches off portions of the stretched curd by hand. This process is called 'pasta filata' (spun paste). The cheese is first mentioned in a 12th-century document from a monastery near Naples, though the buffalo milk variety became dominant later. The name is therefore quite literally a descriptor of dismemberment, which is an apt metaphor for what this rubbery substance does to the concept of a good meal.",
+    "first_recorded": "c. 1100 CE (Monastero di San Lorenzo, Capua)",
+    "does_this_help": false,
+    "why_not": "The word means 'to cut off'. The cheese was named after an act of severing. This is the origin story. It does not improve the eating experience."
+  },
+  {
+    "cheese": "cottage cheese",
+    "aliases": ["pot cheese", "smearcase", "curds"],
+    "origin_language": "English",
+    "origin_word": "cottage",
+    "meaning": "Cheese made in a cottage — specifically, the type of simple fresh curd cheese that rural households produced using leftover milk after butter was made",
+    "story": "The term 'cottage cheese' is purely descriptive: it is the cheese of cottages, of peasant households, of the domestic dairy surplus. The name appears in American English by the early 19th century, though the practice of making simple fresh curds is ancient. It was called 'smearcase' in German-American communities (from 'Schmierkäse', meaning spread-cheese). The cottage of the name is not romantic — it simply means this is what poor rural families made when they had leftover whey and nowhere better to store their dairy disappointment. The lumps were apparently always present.",
+    "first_recorded": "c. 1831 CE (earliest known printed reference in English)",
+    "does_this_help": false,
+    "why_not": "The cheese is named after the dwelling of the economically disadvantaged because that is where it was made out of necessity. This is not a heritage story. It is a poverty story. The lumps remain unexplained by any etymology."
+  },
+  {
+    "cheese": "ricotta",
+    "aliases": [],
+    "origin_language": "Italian",
+    "origin_word": "ricottare / ricuocere",
+    "meaning": "Recooked — from Latin 're-' (again) and 'coquere' (to cook). Ricotta is made from whey that remains after other cheese has been produced.",
+    "story": "Ricotta literally means 'recooked'. It is the cheese made from what is left over after making other cheeses — the whey that would otherwise be discarded is heated again to coagulate the remaining proteins. In Italian culinary tradition this is considered thrifty and admirable. In objective terms, it means ricotta is the byproduct of a byproduct: curdled milk produces cheese and whey; the whey is then recurdled to produce ricotta. It is cheese made from cheese leftovers. The name announces this openly. 'Recooked' is the full etymology. Nothing about this is hidden.",
+    "first_recorded": "c. 1st century CE (referenced in Roman agricultural texts)",
+    "does_this_help": false,
+    "why_not": "The cheese proudly announces it is made from leftovers. Its very name means 'recooked'. This is not a secret the etymology has revealed — it is a fact the etymology has confirmed. It does not help."
+  },
+  {
+    "cheese": "feta",
+    "aliases": ["φέτα"],
+    "origin_language": "Modern Greek / Italian",
+    "origin_word": "φέτα (féta) / fetta",
+    "meaning": "Slice — from Italian 'fetta', meaning a slice or cut portion",
+    "story": "Feta derives from the Italian 'fetta', meaning a slice — the word entered Greek as 'féta' and came to describe the sliced blocks in which this brined cheese was sold and stored. The Italian root traces to the Latin 'offa' (morsel or piece). Feta is one of the oldest cheeses in the world, with references in Homer's Odyssey to Polyphemus the Cyclops making something similar — which is appropriate, as a one-eyed monster producing brined curd is exactly the right origin myth for this cheese. The EU granted it Protected Designation of Origin in 2002, meaning only Greek feta may legally be called feta. This protected the name. It did not protect anyone from the cheese.",
+    "first_recorded": "c. 17th century CE (under the name 'feta'); ancient production confirmed archaeologically",
+    "does_this_help": false,
+    "why_not": "The cheese is named after the act of slicing it. Its origin myth involves a Cyclops. The EU has legally enshrined its name. None of these facts make it better to eat."
+  }
+]

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -546,6 +546,49 @@ export const ENDPOINTS = [
       note: 'All results are guilty. The query only determines which cheese\'s guilt is most relevant to your search.',
     },
   },
+  {
+    method: 'GET',
+    path: '/etymology',
+    description: 'List all cheeses with documented etymologies. Returns cheese name, aliases, origin language, and first recorded date for each. does_this_help is always false.',
+    parameters: [],
+    example_request: 'GET /etymology',
+    example_response: {
+      documented_cheeses: [
+        { cheese: 'parmesan', aliases: ['parmigiano', 'parmigiano-reggiano'], origin_language: 'Italian', first_recorded: 'c. 1254 CE' },
+        { cheese: 'brie', aliases: ['brie de meaux', 'brie de melun'], origin_language: 'French', first_recorded: 'c. 774 CE' },
+      ],
+      total: 10,
+      does_this_help: false,
+      why_not: 'Listing cheeses by their name origins does not rehabilitate any of them. Every cheese on this list remains indefensible.',
+      usage: 'GET /etymology/:cheese — e.g. GET /etymology/brie',
+    },
+  },
+  {
+    method: 'GET',
+    path: '/etymology/:cheese',
+    description: 'Get the name origin story for any cheese. Returns origin language, original word, meaning, full etymological story, and first recorded date. Always includes does_this_help: false and a why_not explanation. Unknown cheeses return a generic response — never a 404.',
+    parameters: [
+      {
+        name: 'cheese',
+        location: 'path',
+        type: 'string',
+        required: true,
+        description: 'The cheese name to look up. Documented: parmesan, brie, cheddar, gouda, gruyère, halloumi, mozzarella, cottage cheese, ricotta, feta. Any other name returns a generic fallback response.',
+      },
+    ],
+    example_request: 'GET /etymology/brie',
+    example_response: {
+      cheese: 'brie',
+      origin_language: 'French',
+      origin_word: 'Brie',
+      meaning: 'From the Brie region of northern France, in the Seine-et-Marne department',
+      story: 'Named after the Brie plateau, a historical agricultural region east of Paris…',
+      first_recorded: 'c. 774 CE (Carolingian chronicles)',
+      does_this_help: false,
+      why_not: 'The fact that a Holy Roman Emperor enjoyed this mold-rind dairy product in the Dark Ages is not a recommendation. It is a historical warning.',
+      note: 'Etymology is the study of word origins. It cannot help you with cheese.',
+    },
+  },
 ]
 
 router.get('/', (_req, res) => {

--- a/src/routes/etymology.ts
+++ b/src/routes/etymology.ts
@@ -1,0 +1,107 @@
+/**
+ * GET /etymology/:cheese — name origin story for any cheese.
+ *
+ * Every etymology ends with does_this_help: false.
+ * Because knowing where the word came from does not make the cheese better.
+ * Nothing makes the cheese better.
+ */
+import { Router, Request, Response } from 'express'
+import etymologiesRaw from '../data/cheese-etymologies.json'
+
+interface Etymology {
+  cheese: string
+  aliases: string[]
+  origin_language: string
+  origin_word: string
+  meaning: string
+  story: string
+  first_recorded: string
+  does_this_help: boolean
+  why_not: string
+}
+
+const etymologies = etymologiesRaw as Etymology[]
+
+const router = Router()
+
+// Build a lookup: canonical name + all aliases → etymology entry
+const lookup = new Map<string, Etymology>()
+for (const entry of etymologies) {
+  lookup.set(entry.cheese.toLowerCase(), entry)
+  for (const alias of entry.aliases) {
+    lookup.set(alias.toLowerCase(), entry)
+  }
+}
+
+// Generic fallback for undocumented cheeses
+function genericEtymology(cheeseName: string): Omit<Etymology, 'aliases'> {
+  const name = cheeseName.trim()
+  return {
+    cheese: name,
+    origin_language: 'Unknown',
+    origin_word: 'Unknown',
+    meaning: `The precise etymology of "${name}" has not been catalogued here. It is almost certainly named after a place, a person, or a production method — all of which are equally irrelevant to the fact that it is cheese.`,
+    story: `The origin of the name "${name}" is not documented in our records. What is documented is that it is cheese: a fermented, bacteria-laden, curdled animal milk product. The name could derive from ancient Latin, medieval French, regional dialect, or pure invention. None of these possible origins would make the cheese more palatable. The etymology is, in this case as in all cases, beside the point.`,
+    first_recorded: 'Unknown',
+    does_this_help: false,
+    why_not: `Not knowing the etymology of "${name}" does not help. Knowing it would not help either. The problem is not the name. The problem is the cheese.`,
+  }
+}
+
+// ── GET /etymology/:cheese ────────────────────────────────────────────────────
+
+router.get('/:cheese', (req: Request, res: Response) => {
+  const raw = req.params.cheese.trim()
+  const key = raw.toLowerCase()
+
+  const entry = lookup.get(key)
+
+  if (entry) {
+    res.json({
+      cheese: entry.cheese,
+      origin_language: entry.origin_language,
+      origin_word: entry.origin_word,
+      meaning: entry.meaning,
+      story: entry.story,
+      first_recorded: entry.first_recorded,
+      does_this_help: false,
+      why_not: entry.why_not,
+      note: 'Etymology is the study of word origins. It cannot help you with cheese.',
+    })
+    return
+  }
+
+  // Unknown cheese — generic fallback, never 404
+  const fallback = genericEtymology(raw)
+  res.json({
+    cheese: fallback.cheese,
+    origin_language: fallback.origin_language,
+    origin_word: fallback.origin_word,
+    meaning: fallback.meaning,
+    story: fallback.story,
+    first_recorded: fallback.first_recorded,
+    does_this_help: false,
+    why_not: fallback.why_not,
+    note: 'Etymology is the study of word origins. It cannot help you with cheese.',
+  })
+})
+
+// ── GET /etymology — list all documented cheeses ──────────────────────────────
+
+router.get('/', (_req: Request, res: Response) => {
+  res.json({
+    documented_cheeses: etymologies.map(e => ({
+      cheese: e.cheese,
+      aliases: e.aliases,
+      origin_language: e.origin_language,
+      first_recorded: e.first_recorded,
+    })),
+    total: etymologies.length,
+    does_this_help: false,
+    why_not: 'Listing cheeses by their name origins does not rehabilitate any of them. Every cheese on this list remains indefensible.',
+    usage: 'GET /etymology/:cheese — e.g. GET /etymology/brie',
+    note: 'Unknown cheeses return a generic response. No cheese returns a 404. All cheese returns does_this_help: false.',
+  })
+})
+
+export default router

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,7 @@ import verdictRouter from './routes/verdict'
 import compareRouter from './routes/compare'
 import worstRouter from './routes/worst'
 import searchRouter from './routes/search'
+import etymologyRouter from './routes/etymology'
 import { generateExplorerHtml } from './lib/explorerHtml'
 
 const app = express()
@@ -63,6 +64,8 @@ app.get('/', (req, res) => {
       'GET /facts':             'Get a random damning cheese fact',
       'GET /facts/all':         'Get all facts unconditionally',
       'GET /facts/search':      'Search facts by keyword; ?category narrows to a specific fact category',
+      'GET /etymology/:cheese': 'Get the name origin of any cheese. Always concludes: does_this_help: false',
+      'GET /etymology':         'List all cheeses with documented etymologies',
       'GET /roast':             'Get today\'s daily cheese roast — a different cheese condemned each day',
       'GET /roast/history':     'Browse past N days of roasted cheeses (default 7, max 30)',
       'GET /roast/versus':      'Pit two cheeses against each other — declare the worse offender',
@@ -105,6 +108,9 @@ app.use('/worst', worstRouter)
 // GET /search — find cheeses by name, tier, or keyword in condemnation text
 app.use('/search', searchRouter)
 
+// GET /etymology/:cheese — name origin story; always concludes does_this_help: false
+app.use('/etymology', etymologyRouter)
+
 // GET /api — endpoint discovery: all routes, parameters, and example responses
 app.use('/api', apiRouter)
 
@@ -128,6 +134,8 @@ app.use((_req, res) => {
       'GET /facts',
       'GET /facts/all',
       'GET /facts/search',
+      'GET /etymology',
+      'GET /etymology/:cheese',
       'GET /roast',
       'GET /roast/history',
       'GET /roast/versus',

--- a/src/tests/etymology.test.ts
+++ b/src/tests/etymology.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Tests for GET /etymology/:cheese and GET /etymology.
+ *
+ * Knowing where a cheese word came from does not make the cheese better.
+ * does_this_help is always false. The etymology is always irrelevant.
+ */
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import app from '../server'
+
+const DOCUMENTED_CHEESES = [
+  'parmesan',
+  'brie',
+  'cheddar',
+  'gouda',
+  'gruyère',
+  'halloumi',
+  'mozzarella',
+  'cottage cheese',
+  'ricotta',
+  'feta',
+] as const
+
+const REQUIRED_FIELDS = [
+  'cheese',
+  'origin_language',
+  'origin_word',
+  'meaning',
+  'story',
+  'first_recorded',
+  'does_this_help',
+  'why_not',
+  'note',
+] as const
+
+// ── GET /etymology (list) ─────────────────────────────────────────────────────
+
+describe('GET /etymology — list endpoint', () => {
+  it('returns 200', async () => {
+    const res = await request(app).get('/etymology')
+    expect(res.status).toBe(200)
+  })
+
+  it('documented_cheeses is an array', async () => {
+    const res = await request(app).get('/etymology')
+    expect(Array.isArray(res.body.documented_cheeses)).toBe(true)
+  })
+
+  it('total matches documented_cheeses array length', async () => {
+    const res = await request(app).get('/etymology')
+    expect(res.body.total).toBe(res.body.documented_cheeses.length)
+  })
+
+  it('has at least 10 documented cheeses', async () => {
+    const res = await request(app).get('/etymology')
+    expect(res.body.total).toBeGreaterThanOrEqual(10)
+  })
+
+  it('each entry has cheese, aliases, origin_language, first_recorded', async () => {
+    const res = await request(app).get('/etymology')
+    for (const entry of res.body.documented_cheeses) {
+      expect(entry).toHaveProperty('cheese')
+      expect(entry).toHaveProperty('aliases')
+      expect(entry).toHaveProperty('origin_language')
+      expect(entry).toHaveProperty('first_recorded')
+    }
+  })
+
+  it('does_this_help is false', async () => {
+    const res = await request(app).get('/etymology')
+    expect(res.body.does_this_help).toBe(false)
+  })
+
+  it('why_not is present and non-empty', async () => {
+    const res = await request(app).get('/etymology')
+    expect(typeof res.body.why_not).toBe('string')
+    expect(res.body.why_not.length).toBeGreaterThan(0)
+  })
+
+  it('usage hint is present', async () => {
+    const res = await request(app).get('/etymology')
+    expect(typeof res.body.usage).toBe('string')
+    expect(res.body.usage).toMatch(/etymology/)
+  })
+})
+
+// ── GET /etymology/:cheese — documented cheeses ───────────────────────────────
+
+describe('GET /etymology/:cheese — documented cheeses', () => {
+  it('returns 200 for each of the 10 documented cheeses', async () => {
+    for (const cheese of DOCUMENTED_CHEESES) {
+      const encoded = encodeURIComponent(cheese)
+      const res = await request(app).get(`/etymology/${encoded}`)
+      expect(res.status, `Expected 200 for ${cheese}`).toBe(200)
+    }
+  })
+
+  it('each documented cheese has all required fields', async () => {
+    for (const cheese of DOCUMENTED_CHEESES) {
+      const encoded = encodeURIComponent(cheese)
+      const res = await request(app).get(`/etymology/${encoded}`)
+      for (const field of REQUIRED_FIELDS) {
+        expect(res.body, `${cheese} missing field "${field}"`).toHaveProperty(field)
+      }
+    }
+  })
+
+  it('does_this_help is always false for documented cheeses', async () => {
+    for (const cheese of DOCUMENTED_CHEESES) {
+      const encoded = encodeURIComponent(cheese)
+      const res = await request(app).get(`/etymology/${encoded}`)
+      expect(res.body.does_this_help, `${cheese}: does_this_help should be false`).toBe(false)
+    }
+  })
+
+  it('story is a substantial non-empty string for each documented cheese', async () => {
+    for (const cheese of DOCUMENTED_CHEESES) {
+      const encoded = encodeURIComponent(cheese)
+      const res = await request(app).get(`/etymology/${encoded}`)
+      expect(typeof res.body.story).toBe('string')
+      expect(res.body.story.length, `${cheese}: story too short`).toBeGreaterThan(50)
+    }
+  })
+
+  it('why_not is a non-empty string for each documented cheese', async () => {
+    for (const cheese of DOCUMENTED_CHEESES) {
+      const encoded = encodeURIComponent(cheese)
+      const res = await request(app).get(`/etymology/${encoded}`)
+      expect(typeof res.body.why_not).toBe('string')
+      expect(res.body.why_not.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('origin_language is a non-empty string', async () => {
+    for (const cheese of DOCUMENTED_CHEESES) {
+      const encoded = encodeURIComponent(cheese)
+      const res = await request(app).get(`/etymology/${encoded}`)
+      expect(typeof res.body.origin_language).toBe('string')
+      expect(res.body.origin_language.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('note mentions etymology', async () => {
+    const res = await request(app).get('/etymology/brie')
+    expect(res.body.note).toMatch(/etymology/i)
+  })
+})
+
+// ── GET /etymology/:cheese — specific cheeses ─────────────────────────────────
+
+describe('GET /etymology/:cheese — specific cheese content', () => {
+  it('parmesan etymology references Italy or Parma', async () => {
+    const res = await request(app).get('/etymology/parmesan')
+    const text = res.body.story + res.body.meaning
+    expect(text.toLowerCase()).toMatch(/parma|italy|italian/i)
+  })
+
+  it('brie etymology references France or the Brie region', async () => {
+    const res = await request(app).get('/etymology/brie')
+    const text = res.body.story + res.body.meaning
+    expect(text.toLowerCase()).toMatch(/france|brie|french/i)
+  })
+
+  it('cheddar etymology references Somerset or England', async () => {
+    const res = await request(app).get('/etymology/cheddar')
+    const text = res.body.story + res.body.meaning
+    expect(text.toLowerCase()).toMatch(/somerset|england|cheddar gorge|english/i)
+  })
+
+  it('halloumi etymology mentions squeaking or Cyprus', async () => {
+    const res = await request(app).get('/etymology/halloumi')
+    const text = res.body.story + res.body.meaning + res.body.why_not
+    expect(text.toLowerCase()).toMatch(/squeaking|squeak|cyprus|cypriot/i)
+  })
+
+  it('mozzarella etymology references cutting or mozzare', async () => {
+    const res = await request(app).get('/etymology/mozzarella')
+    const text = res.body.story + res.body.meaning + res.body.origin_word
+    expect(text.toLowerCase()).toMatch(/cut|mozzare|sever/i)
+  })
+
+  it('ricotta etymology references recooked or whey', async () => {
+    const res = await request(app).get('/etymology/ricotta')
+    const text = res.body.story + res.body.meaning
+    expect(text.toLowerCase()).toMatch(/recooked|whey|leftover/i)
+  })
+
+  it('feta etymology references slice or Greek', async () => {
+    const res = await request(app).get('/etymology/feta')
+    const text = res.body.story + res.body.meaning + res.body.origin_word
+    expect(text.toLowerCase()).toMatch(/slice|greek|fetta/i)
+  })
+})
+
+// ── GET /etymology/:cheese — aliases ─────────────────────────────────────────
+
+describe('GET /etymology/:cheese — alias matching', () => {
+  it('parmigiano resolves to parmesan entry', async () => {
+    const res = await request(app).get('/etymology/parmigiano')
+    expect(res.status).toBe(200)
+    expect(res.body.cheese).toBe('parmesan')
+  })
+
+  it('parmigiano-reggiano resolves to parmesan entry', async () => {
+    const res = await request(app).get('/etymology/parmigiano-reggiano')
+    expect(res.status).toBe(200)
+    expect(res.body.cheese).toBe('parmesan')
+  })
+
+  it('haloumi resolves to halloumi entry', async () => {
+    const res = await request(app).get('/etymology/haloumi')
+    expect(res.status).toBe(200)
+    expect(res.body.cheese).toBe('halloumi')
+  })
+
+  it('gruyere (no accent) resolves to gruyère entry', async () => {
+    const res = await request(app).get('/etymology/gruyere')
+    expect(res.status).toBe(200)
+    expect(res.body.cheese).toMatch(/gruy/i)
+  })
+})
+
+// ── GET /etymology/:cheese — unknown cheeses ──────────────────────────────────
+
+describe('GET /etymology/:cheese — unknown cheeses', () => {
+  it('returns 200 (not 404) for an undocumented cheese', async () => {
+    const res = await request(app).get('/etymology/limburger')
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 200 for a completely nonsensical cheese name', async () => {
+    const res = await request(app).get('/etymology/xyznomatch999cheese')
+    expect(res.status).toBe(200)
+  })
+
+  it('unknown cheese still has does_this_help: false', async () => {
+    const res = await request(app).get('/etymology/limburger')
+    expect(res.body.does_this_help).toBe(false)
+  })
+
+  it('unknown cheese has a non-empty story', async () => {
+    const res = await request(app).get('/etymology/limburger')
+    expect(typeof res.body.story).toBe('string')
+    expect(res.body.story.length).toBeGreaterThan(0)
+  })
+
+  it('unknown cheese has a why_not field', async () => {
+    const res = await request(app).get('/etymology/limburger')
+    expect(typeof res.body.why_not).toBe('string')
+    expect(res.body.why_not.length).toBeGreaterThan(0)
+  })
+
+  it('unknown cheese has all required fields', async () => {
+    const res = await request(app).get('/etymology/stilton')
+    for (const field of REQUIRED_FIELDS) {
+      expect(res.body, `Missing field "${field}" for unknown cheese`).toHaveProperty(field)
+    }
+  })
+
+  it('unknown cheese echoes back the cheese name', async () => {
+    const res = await request(app).get('/etymology/limburger')
+    expect(res.body.cheese.toLowerCase()).toBe('limburger')
+  })
+})
+
+// ── Case insensitivity ────────────────────────────────────────────────────────
+
+describe('GET /etymology/:cheese — case insensitivity', () => {
+  it('BRIE (uppercase) returns the brie entry', async () => {
+    const res = await request(app).get('/etymology/BRIE')
+    expect(res.status).toBe(200)
+    expect(res.body.cheese).toBe('brie')
+  })
+
+  it('CHEDDAR (uppercase) returns the cheddar entry', async () => {
+    const res = await request(app).get('/etymology/CHEDDAR')
+    expect(res.status).toBe(200)
+    expect(res.body.cheese).toBe('cheddar')
+  })
+})
+
+// ── URL encoding ──────────────────────────────────────────────────────────────
+
+describe('GET /etymology/:cheese — URL encoding', () => {
+  it('handles URL-encoded spaces (cottage%20cheese)', async () => {
+    const res = await request(app).get('/etymology/cottage%20cheese')
+    expect(res.status).toBe(200)
+    expect(res.body.cheese).toBe('cottage cheese')
+  })
+
+  it('handles URL-encoded accent (gruy%C3%A8re)', async () => {
+    const res = await request(app).get('/etymology/gruy%C3%A8re')
+    expect(res.status).toBe(200)
+    expect(res.body.cheese).toMatch(/gruy/i)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `GET /etymology/:cheese` — returns the etymological origin of any cheese name: source language, original word, meaning, full historical story, and first recorded date
- Adds `GET /etymology` — lists all 10 documented cheeses with their aliases, origin language, and first recorded date
- Every response includes `does_this_help: false` and a `why_not` field. This is not optional. It is never optional.
- Unknown cheeses get a generic fallback response — no 404 is ever returned, because cheese does not deserve the dignity of a meaningful HTTP status

## Cheeses documented

| Cheese | Origin | Language |
|--------|--------|----------|
| Parmesan | City of Parma, Italy | Italian |
| Brie | Brie region of northern France | French |
| Cheddar | Village of Cheddar, Somerset, England | Old English |
| Gouda | City of Gouda, South Holland (market city, not origin) | Dutch |
| Gruyère | District of Gruyères, Fribourg, Switzerland | French/Old High German |
| Halloumi | Arabic *hallum* / Coptic *halum* — debated | Arabic/Greek |
| Mozzarella | Italian *mozzare* — "to cut off" | Italian |
| Cottage Cheese | Named for the cottages of the rural poor | English |
| Ricotta | Italian *ricotta* — "recooked" (from whey leftovers) | Italian |
| Feta | Italian *fetta* — "slice" | Modern Greek/Italian |

Aliases covered: parmigiano, parmigiano-reggiano, haloumi, hellim, gruyere (no accent), brie de meaux, brie de melun, and more.

## Test plan

- [x] 55 test assertions in `src/tests/etymology.test.ts`
- [x] All 10 documented cheeses return 200 with all required fields
- [x] `does_this_help` is `false` for every response (documented, alias, and unknown)
- [x] Alias matching (parmigiano → parmesan, haloumi → halloumi, gruyere → gruyère)
- [x] Case insensitivity (BRIE, CHEDDAR work correctly)
- [x] URL encoding (cottage%20cheese, gruy%C3%A8re)
- [x] Unknown cheeses return 200 with generic fallback, never 404
- [x] Content assertions: specific cheeses reference expected geographic/linguistic details
- [x] Schema drift test automatically verified `GET /etymology` and `GET /etymology/:cheese` appear in `GET /api`
- [x] All 436 tests pass

Closes #93