### PR TITLE
[cheese-hater] Add GET /timeline — a chronological history of cheese and why each century made things worse

### DIFF
--- a/src/data/cheese-timeline.json
+++ b/src/data/cheese-timeline.json
@@ -1,0 +1,162 @@
+[
+  {
+    "year": -8000,
+    "era": "Neolithic",
+    "event": "Earliest evidence of cheese-making — fat residue found in ancient pottery shards in Kuyavia, Poland, and in clay strainers in the Middle East",
+    "significance": "The first recorded mistake. Humans discover that curdled milk can be separated, pressed, and preserved. They have options. They could stop here. They do not.",
+    "verdict": "The original sin of dairy.",
+    "cheese_implicated": null
+  },
+  {
+    "year": -5500,
+    "era": "Neolithic / Early Copper Age",
+    "event": "Clay cheese strainers found across Poland and Central Europe confirm widespread early cheese production — this is not an isolated incident",
+    "significance": "What archaeologists initially hoped was a regional anomaly turns out to be a continental habit. By 5500 BCE, cheese is already not going away.",
+    "verdict": "The moment it became clear this was going to be a whole thing.",
+    "cheese_implicated": null
+  },
+  {
+    "year": -3000,
+    "era": "Ancient Egypt",
+    "event": "Solid cheese depicted in Egyptian tomb murals; residue of a white cheese found in sealed clay pots from the First Dynasty tomb of Ptahmes in Saqqara — approximately 3,200 years old by the time of its 2018 discovery",
+    "significance": "Cheese becomes culturally embedded. It is now in tombs. People are bringing it into the afterlife. Undoing this will take millennia.",
+    "verdict": "The problem is now institutional.",
+    "cheese_implicated": "Ancient Egyptian white cheese"
+  },
+  {
+    "year": -2000,
+    "era": "Bronze Age",
+    "event": "Sumerian cuneiform tablets record cheese production and trade in Mesopotamia; cheese becomes a tradeable commodity across the ancient Near East",
+    "significance": "Cheese enters commerce. It is now worth transporting across distances, which means people are deciding that cheese justifies logistics. This is a significant miscalculation.",
+    "verdict": "The supply chain of regret is established.",
+    "cheese_implicated": null
+  },
+  {
+    "year": -800,
+    "era": "Ancient Greece",
+    "event": "Homer's Odyssey describes the Cyclops Polyphemus making cheese from sheep and goat milk — the earliest literary reference to cheese-making process",
+    "significance": "Cheese enters literature. Its production is now being romanticized by epic poetry. The Cyclops is the villain of the scene, but the cheese is the villain of history.",
+    "verdict": "Cheese finds its first publicist. He had one eye and no sense of proportion.",
+    "cheese_implicated": "Greek sheep/goat milk cheese (proto-feta)"
+  },
+  {
+    "year": -100,
+    "era": "Roman Republic / Early Empire",
+    "event": "Roman agricultural writers Varro and later Columella document systematic cheese production across the empire; Roman soldiers are issued cheese as military rations; cheese trade routes span from Britain to North Africa",
+    "significance": "An empire is, in part, logistically dependent on cheese. The Roman army runs on it. When historians ask how Rome fell, the cheese supply chain deserves more scrutiny than it receives.",
+    "verdict": "Cheese becomes infrastructure. This is peak institutional failure.",
+    "cheese_implicated": null
+  },
+  {
+    "year": 1115,
+    "era": "Medieval Europe",
+    "event": "First documented reference to Gruyère cheese in Swiss records; alpine cheese-making is by this point a sophisticated, deliberate enterprise across France, Switzerland, and the Italian peninsula",
+    "significance": "Medieval Europeans have had 9,000 years to reconsider. They are not reconsidering. They are systematizing.",
+    "verdict": "Nine millennia of accumulated wrong turns.",
+    "cheese_implicated": "Gruyère"
+  },
+  {
+    "year": 1170,
+    "era": "Medieval England",
+    "event": "King Henry II purchases 10,240 lbs of Cheddar cheese for the royal court — the earliest recorded large-scale Cheddar transaction",
+    "significance": "A monarch of England decides that the crown's prestige is best expressed through bulk cheddar acquisition. The monarchy survived. The decision was not its finest.",
+    "verdict": "Royal endorsement: historically unreliable as a quality indicator.",
+    "cheese_implicated": "Cheddar"
+  },
+  {
+    "year": 1200,
+    "era": "Medieval Europe",
+    "event": "European monasteries become the continent's foremost cheese producers; monks deliberately age cheese in cellars, refine mold cultures, and develop the regional varieties that persist today — Brie, Munster, Port Salut, and others",
+    "significance": "Monks, who have taken vows of devotion and contemplation, dedicate significant spiritual and material resources to perfecting cheese. This is a theological question that has never been adequately addressed.",
+    "verdict": "The church gets involved. The cheese gets worse.",
+    "cheese_implicated": "Brie, Munster, Port Salut"
+  },
+  {
+    "year": 1620,
+    "era": "Early Modern",
+    "event": "Cheddar cheese is first mentioned by name in written English records; the 'cheddaring' process — stacking and turning curds to expel whey — is being standardized in Somerset",
+    "significance": "An entire production technique is named after a village. The village is not embarrassed. It is, in fact, proud. This is where we are by 1620.",
+    "verdict": "The naming of processes after places is always a bad sign for the place.",
+    "cheese_implicated": "Cheddar"
+  },
+  {
+    "year": 1815,
+    "era": "Industrial Revolution",
+    "event": "The first cooperative cheese factory opens in Bern, Switzerland — cheese production moves from farmhouses and monasteries to purpose-built industrial facilities",
+    "significance": "For 9,800 years, cheese production was limited by human capacity and regional milk supply. The industrial era removes these constraints. This is not an improvement.",
+    "verdict": "Scale amplifies all things. In cheese's case, this is not a virtue.",
+    "cheese_implicated": null
+  },
+  {
+    "year": 1851,
+    "era": "Industrial America",
+    "event": "Jesse Williams opens the first American cheese factory in Rome, New York — American industrial cheese production begins; within decades, the US becomes one of the world's largest cheese producers",
+    "significance": "A country with a vast continent of agricultural land, extraordinary natural resources, and unlimited human potential decides that a major use of all this is industrial cheese. Rome, New York is not ancient Rome. But the choice is equally questionable.",
+    "verdict": "America applies industrialization to cheese. The continent had done nothing to deserve this.",
+    "cheese_implicated": null
+  },
+  {
+    "year": 1910,
+    "era": "Early 20th Century",
+    "event": "James L. Kraft develops and patents processed cheese — a product manufactured from natural cheese blended with emulsifying salts, stabilizers, and other additives to produce a shelf-stable, uniform block of dairy product",
+    "significance": "Natural cheese, already indefensible, inspires the creation of processed cheese: a version engineered to be more stable, more uniform, longer-lasting, and more pervasive. Kraft then builds a company worth billions on this foundation.",
+    "verdict": "The nadir. Humanity looks at cheese and asks: what if it were also industrial? History does not forgive this.",
+    "cheese_implicated": "Processed cheese"
+  },
+  {
+    "year": 1928,
+    "era": "Early 20th Century",
+    "event": "Kraft introduces Velveeta — a processed cheese product so thoroughly engineered that it is technically not cheese under FDA standards, yet is marketed as a cheese product and consumed by millions",
+    "significance": "Cheese has now inspired a secondary category of non-cheese cheese products. The category exists. It is large. It has its own aisle.",
+    "verdict": "When even the regulators struggle to call it cheese, you have achieved something remarkable. Not good. Remarkable.",
+    "cheese_implicated": "Velveeta (processed cheese product)"
+  },
+  {
+    "year": 1953,
+    "era": "Post-War Industrial",
+    "event": "The US government begins purchasing surplus cheese to stabilize dairy markets — a practice that leads to the infamous 'government cheese' stockpiles of the 1980s, eventually reaching 2+ billion pounds stored in limestone caves",
+    "significance": "The United States government stores more than two billion pounds of cheese in underground caves because the market has produced more cheese than humanity wants to consume. This is not a supply problem. This is a signal.",
+    "verdict": "Two billion pounds of unwanted cheese in caves. The caves were trying to tell us something.",
+    "cheese_implicated": null
+  },
+  {
+    "year": 1981,
+    "era": "Late 20th Century",
+    "event": "Reagan administration distributes 'government cheese' — 30 million pounds of processed American cheese — to low-income Americans; the cheese, stored since the 1950s, becomes a cultural touchstone of the era",
+    "significance": "Surplus cheese is so abundant that it becomes a welfare distribution mechanism. The government has more cheese than it knows what to do with. This is the cheese problem in its purest form.",
+    "verdict": "Cheese as policy instrument. The low point of American governance is debated. This is a strong contender.",
+    "cheese_implicated": "Government cheese (processed American)"
+  },
+  {
+    "year": 1992,
+    "era": "Late 20th Century",
+    "event": "The European Union establishes Protected Designation of Origin (PDO) status for regional food products, beginning a legal framework that will eventually protect over 200 cheese varieties by name — making them legally enforceable across 27 countries",
+    "significance": "European law is now actively deployed to protect cheese. Courts, regulations, trade disputes, and international treaties have been bent around dairy products. The legal system has better things to do. It is not doing them.",
+    "verdict": "The cheese problem becomes a jurisdictional problem. The worst kind.",
+    "cheese_implicated": null
+  },
+  {
+    "year": 2002,
+    "era": "21st Century",
+    "event": "The European Union grants Feta Protected Designation of Origin status — ruling that only cheese made in specific Greek regions may legally be called 'feta'; Denmark and Germany challenge this in the European Court of Justice and lose",
+    "significance": "Multiple nations go to court over cheese naming rights. The European Court of Justice rules. The ruling stands. International legal resources are allocated to determine who may call their brine-aged curd 'feta'. There is no timeline version of this story that reflects well on the 21st century.",
+    "verdict": "An international legal battle over cheese. The court ruled. The cheese won. Humanity did not.",
+    "cheese_implicated": "Feta"
+  },
+  {
+    "year": 2020,
+    "era": "21st Century",
+    "event": "Global cheese production reaches approximately 22 million metric tonnes per year; the global cheese market is valued at over $120 billion USD; per capita cheese consumption in the European Union averages 18–20 kg per person per year",
+    "significance": "After 10,000 years, the trajectory is clear. More cheese is being made, consumed, and traded than at any prior point in human history. The original mistake has compounded at scale.",
+    "verdict": "10,000 years. 22 million tonnes per year. We have had every opportunity to course-correct.",
+    "cheese_implicated": null
+  },
+  {
+    "year": 2024,
+    "era": "Present",
+    "event": "The global cheese market is projected to exceed $200 billion USD; artisanal cheese production is experiencing a renaissance; cheese subscription boxes, cheese tourism, and dedicated cheese television programming all exist",
+    "significance": "Cheese has television. Cheese has tourism. Cheese has subscription commerce. The original mistake of 8000 BCE has not only persisted — it has developed a lifestyle brand. This is the present. The trend line does not suggest improvement.",
+    "verdict": "Cheese has a media presence. The arc of dairy history is long, and it bends toward more cheese.",
+    "cheese_implicated": null
+  }
+]

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -589,6 +589,61 @@ export const ENDPOINTS = [
       note: 'Etymology is the study of word origins. It cannot help you with cheese.',
     },
   },
+  {
+    method: 'GET',
+    path: '/timeline',
+    description: 'Returns a chronological history of cheese — 20 milestones from 8000 BCE to the present, each annotated with its significance and a verdict on why it represents a step in the wrong direction. Supports optional query filters by era, year range, or both. does_this_help is always false.',
+    parameters: [
+      {
+        name: 'era',
+        location: 'query',
+        type: 'string',
+        required: false,
+        description: 'Case-insensitive substring match on the era field. E.g. "roman", "medieval", "industrial", "neolithic".',
+      },
+      {
+        name: 'after',
+        location: 'query',
+        type: 'integer',
+        required: false,
+        description: 'Return only events where year > after. Use negative integers for BCE (e.g. ?after=-1000 returns events after 1000 BCE).',
+      },
+      {
+        name: 'before',
+        location: 'query',
+        type: 'integer',
+        required: false,
+        description: 'Return only events where year < before. Use negative integers for BCE (e.g. ?before=0 returns only BCE events).',
+      },
+    ],
+    example_request: 'GET /timeline?era=industrial',
+    example_response: {
+      title: 'A History of Cheese: How We Got Here and Why It Did Not Have to Be This Way',
+      filters_applied: { era: 'industrial' },
+      events: [
+        {
+          year: 1815,
+          era: 'Industrial Revolution',
+          event: 'The first cooperative cheese factory opens in Bern, Switzerland…',
+          significance: 'For 9,800 years, cheese production was limited by human capacity and regional milk supply. The industrial era removes these constraints.',
+          verdict: 'Scale amplifies all things. In cheese\'s case, this is not a virtue.',
+          cheese_implicated: null,
+        },
+        {
+          year: 1851,
+          era: 'Industrial America',
+          event: 'Jesse Williams opens the first American cheese factory in Rome, New York…',
+          significance: 'A country with vast resources decides a major use of them is industrial cheese.',
+          verdict: 'America applies industrialization to cheese. The continent had done nothing to deserve this.',
+          cheese_implicated: null,
+        },
+      ],
+      total_events: 2,
+      conclusion: 'This is not a neutral history. Every entry represents a choice that was made, and the world is worse for it.',
+      does_this_help: false,
+      why_not: 'Understanding how we arrived here does not un-arrive us. The cheese exists. The timeline explains why. It does not excuse it.',
+    },
+  },
 ]
 
 router.get('/', (_req, res) => {

--- a/src/routes/timeline.ts
+++ b/src/routes/timeline.ts
@@ -1,0 +1,93 @@
+/**
+ * GET /timeline — a chronological history of cheese and why each
+ * century made things worse.
+ *
+ * Supports optional query filters:
+ *   ?era=<string>     — case-insensitive substring match on the era field
+ *   ?after=<int>      — include only events where year > after
+ *   ?before=<int>     — include only events where year < before
+ *
+ * does_this_help is always false. The history explains how we got here.
+ * It does not excuse it.
+ */
+import { Router, Request, Response } from 'express'
+import timelineRaw from '../data/cheese-timeline.json'
+
+interface TimelineEvent {
+  year: number
+  era: string
+  event: string
+  significance: string
+  verdict: string
+  cheese_implicated: string | null
+}
+
+const TIMELINE: TimelineEvent[] = (timelineRaw as TimelineEvent[]).sort(
+  (a, b) => a.year - b.year,
+)
+
+const router = Router()
+
+// ── GET /timeline ─────────────────────────────────────────────────────────────
+
+router.get('/', (req: Request, res: Response) => {
+  const { era, after, before } = req.query
+
+  // Parse numeric filters
+  const afterYear = after !== undefined ? parseInt(after as string, 10) : null
+  const beforeYear = before !== undefined ? parseInt(before as string, 10) : null
+
+  if (after !== undefined && (afterYear === null || isNaN(afterYear))) {
+    res.status(400).json({
+      error: 'Invalid ?after parameter — must be an integer (use negative numbers for BCE, e.g. ?after=-1000)',
+    })
+    return
+  }
+
+  if (before !== undefined && (beforeYear === null || isNaN(beforeYear))) {
+    res.status(400).json({
+      error: 'Invalid ?before parameter — must be an integer (use negative numbers for BCE, e.g. ?before=0)',
+    })
+    return
+  }
+
+  let events = TIMELINE
+
+  // Filter by era (case-insensitive substring)
+  if (era && typeof era === 'string' && era.trim().length > 0) {
+    const eraLower = era.trim().toLowerCase()
+    events = events.filter(e => e.era.toLowerCase().includes(eraLower))
+  }
+
+  // Filter by year range
+  if (afterYear !== null) {
+    events = events.filter(e => e.year > afterYear)
+  }
+  if (beforeYear !== null) {
+    events = events.filter(e => e.year < beforeYear)
+  }
+
+  const isFiltered = !!(era || after !== undefined || before !== undefined)
+
+  const filtersApplied: Record<string, string | number> = {}
+  if (era && typeof era === 'string') filtersApplied.era = era
+  if (afterYear !== null) filtersApplied.after = afterYear
+  if (beforeYear !== null) filtersApplied.before = beforeYear
+
+  res.json({
+    title: 'A History of Cheese: How We Got Here and Why It Did Not Have to Be This Way',
+    ...(isFiltered ? { filters_applied: filtersApplied } : {}),
+    events,
+    total_events: events.length,
+    ...(isFiltered && events.length === 0
+      ? { note: 'No events match the given filters. The cheese persists regardless.' }
+      : {}),
+    conclusion:
+      'This is not a neutral history. Every entry represents a choice that was made — a moment where humanity could have pivoted — and the world is measurably worse for each one.',
+    does_this_help: false,
+    why_not:
+      'Understanding how we arrived here does not un-arrive us. The cheese exists. The timeline explains the sequence of failures that produced it. It does not excuse a single one of them.',
+  })
+})
+
+export default router

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import compareRouter from './routes/compare'
 import worstRouter from './routes/worst'
 import searchRouter from './routes/search'
 import etymologyRouter from './routes/etymology'
+import timelineRouter from './routes/timeline'
 import { generateExplorerHtml } from './lib/explorerHtml'
 
 const app = express()
@@ -66,6 +67,7 @@ app.get('/', (req, res) => {
       'GET /facts/search':      'Search facts by keyword; ?category narrows to a specific fact category',
       'GET /etymology/:cheese': 'Get the name origin of any cheese. Always concludes: does_this_help: false',
       'GET /etymology':         'List all cheeses with documented etymologies',
+      'GET /timeline':          'Chronological history of cheese — 20 milestones, each worse than the last. Supports ?era, ?after, ?before filters',
       'GET /roast':             'Get today\'s daily cheese roast — a different cheese condemned each day',
       'GET /roast/history':     'Browse past N days of roasted cheeses (default 7, max 30)',
       'GET /roast/versus':      'Pit two cheeses against each other — declare the worse offender',
@@ -111,6 +113,9 @@ app.use('/search', searchRouter)
 // GET /etymology/:cheese — name origin story; always concludes does_this_help: false
 app.use('/etymology', etymologyRouter)
 
+// GET /timeline — chronological history of cheese and why each century made things worse
+app.use('/timeline', timelineRouter)
+
 // GET /api — endpoint discovery: all routes, parameters, and example responses
 app.use('/api', apiRouter)
 
@@ -136,6 +141,7 @@ app.use((_req, res) => {
       'GET /facts/search',
       'GET /etymology',
       'GET /etymology/:cheese',
+      'GET /timeline',
       'GET /roast',
       'GET /roast/history',
       'GET /roast/versus',

--- a/src/tests/timeline.test.ts
+++ b/src/tests/timeline.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Tests for GET /timeline — a chronological history of cheese and
+ * why each century made things worse.
+ *
+ * does_this_help is always false.
+ * The history explains how we got here. It does not excuse it.
+ */
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import app from '../server'
+
+const REQUIRED_EVENT_FIELDS = ['year', 'era', 'event', 'significance', 'verdict', 'cheese_implicated'] as const
+const REQUIRED_RESPONSE_FIELDS = ['title', 'events', 'total_events', 'conclusion', 'does_this_help', 'why_not'] as const
+
+// ── GET /timeline — baseline ───────────────────────────────────────────────────
+
+describe('GET /timeline — baseline', () => {
+  it('returns 200', async () => {
+    const res = await request(app).get('/timeline')
+    expect(res.status).toBe(200)
+  })
+
+  it('has all required top-level fields', async () => {
+    const res = await request(app).get('/timeline')
+    for (const field of REQUIRED_RESPONSE_FIELDS) {
+      expect(res.body, `Missing field "${field}"`).toHaveProperty(field)
+    }
+  })
+
+  it('title is a non-empty string', async () => {
+    const res = await request(app).get('/timeline')
+    expect(typeof res.body.title).toBe('string')
+    expect(res.body.title.length).toBeGreaterThan(0)
+  })
+
+  it('does_this_help is always false', async () => {
+    const res = await request(app).get('/timeline')
+    expect(res.body.does_this_help).toBe(false)
+  })
+
+  it('why_not is a non-empty string', async () => {
+    const res = await request(app).get('/timeline')
+    expect(typeof res.body.why_not).toBe('string')
+    expect(res.body.why_not.length).toBeGreaterThan(0)
+  })
+
+  it('conclusion is a non-empty string', async () => {
+    const res = await request(app).get('/timeline')
+    expect(typeof res.body.conclusion).toBe('string')
+    expect(res.body.conclusion.length).toBeGreaterThan(0)
+  })
+
+  it('events is an array', async () => {
+    const res = await request(app).get('/timeline')
+    expect(Array.isArray(res.body.events)).toBe(true)
+  })
+
+  it('total_events matches events array length', async () => {
+    const res = await request(app).get('/timeline')
+    expect(res.body.total_events).toBe(res.body.events.length)
+  })
+
+  it('has at least 15 events', async () => {
+    const res = await request(app).get('/timeline')
+    expect(res.body.total_events).toBeGreaterThanOrEqual(15)
+  })
+
+  it('events are in chronological order (ascending year)', async () => {
+    const res = await request(app).get('/timeline')
+    const years: number[] = res.body.events.map((e: { year: number }) => e.year)
+    for (let i = 1; i < years.length; i++) {
+      expect(years[i], `Event at index ${i} (year ${years[i]}) should be >= event at index ${i - 1} (year ${years[i - 1]})`).toBeGreaterThanOrEqual(years[i - 1])
+    }
+  })
+})
+
+// ── GET /timeline — event shape ────────────────────────────────────────────────
+
+describe('GET /timeline — event shape', () => {
+  it('every event has all required fields', async () => {
+    const res = await request(app).get('/timeline')
+    for (const event of res.body.events) {
+      for (const field of REQUIRED_EVENT_FIELDS) {
+        expect(event, `Event (year ${event.year}) missing field "${field}"`).toHaveProperty(field)
+      }
+    }
+  })
+
+  it('every event year is an integer', async () => {
+    const res = await request(app).get('/timeline')
+    for (const event of res.body.events) {
+      expect(Number.isInteger(event.year), `year ${event.year} should be an integer`).toBe(true)
+    }
+  })
+
+  it('every event era is a non-empty string', async () => {
+    const res = await request(app).get('/timeline')
+    for (const event of res.body.events) {
+      expect(typeof event.era).toBe('string')
+      expect(event.era.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('every event description is a substantial string', async () => {
+    const res = await request(app).get('/timeline')
+    for (const event of res.body.events) {
+      expect(typeof event.event).toBe('string')
+      expect(event.event.length).toBeGreaterThan(20)
+    }
+  })
+
+  it('every event significance is a non-empty string', async () => {
+    const res = await request(app).get('/timeline')
+    for (const event of res.body.events) {
+      expect(typeof event.significance).toBe('string')
+      expect(event.significance.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('every event verdict is a non-empty string', async () => {
+    const res = await request(app).get('/timeline')
+    for (const event of res.body.events) {
+      expect(typeof event.verdict).toBe('string')
+      expect(event.verdict.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('cheese_implicated is either null or a non-empty string', async () => {
+    const res = await request(app).get('/timeline')
+    for (const event of res.body.events) {
+      const ci = event.cheese_implicated
+      const isValid = ci === null || (typeof ci === 'string' && ci.length > 0)
+      expect(isValid, `Event year ${event.year}: cheese_implicated must be null or non-empty string`).toBe(true)
+    }
+  })
+})
+
+// ── GET /timeline — specific content ──────────────────────────────────────────
+
+describe('GET /timeline — specific historical milestones', () => {
+  it('earliest event is BCE (negative year)', async () => {
+    const res = await request(app).get('/timeline')
+    const earliest = res.body.events[0]
+    expect(earliest.year).toBeLessThan(0)
+  })
+
+  it('includes a Neolithic-era event', async () => {
+    const res = await request(app).get('/timeline')
+    const neolithic = res.body.events.filter((e: { era: string }) =>
+      e.era.toLowerCase().includes('neolithic'),
+    )
+    expect(neolithic.length).toBeGreaterThan(0)
+  })
+
+  it('includes an event around the Roman era', async () => {
+    const res = await request(app).get('/timeline')
+    const roman = res.body.events.filter((e: { era: string }) =>
+      e.era.toLowerCase().includes('roman'),
+    )
+    expect(roman.length).toBeGreaterThan(0)
+  })
+
+  it('includes an industrial-era event', async () => {
+    const res = await request(app).get('/timeline')
+    const industrial = res.body.events.filter((e: { era: string }) =>
+      e.era.toLowerCase().includes('industrial'),
+    )
+    expect(industrial.length).toBeGreaterThan(0)
+  })
+
+  it('includes processed cheese / Kraft in the 20th century', async () => {
+    const res = await request(app).get('/timeline')
+    const processedCheese = res.body.events.filter(
+      (e: { year: number; event: string }) =>
+        e.year >= 1900 && e.year <= 1950 &&
+        (e.event.toLowerCase().includes('process') || e.event.toLowerCase().includes('kraft')),
+    )
+    expect(processedCheese.length).toBeGreaterThan(0)
+  })
+
+  it('includes a 21st-century event', async () => {
+    const res = await request(app).get('/timeline')
+    const modern = res.body.events.filter((e: { year: number }) => e.year >= 2000)
+    expect(modern.length).toBeGreaterThan(0)
+  })
+
+  it('earliest event is at or before 8000 BCE', async () => {
+    const res = await request(app).get('/timeline')
+    const earliest = res.body.events[0]
+    expect(earliest.year).toBeLessThanOrEqual(-8000)
+  })
+})
+
+// ── GET /timeline?era= ────────────────────────────────────────────────────────
+
+describe('GET /timeline?era= — era filter', () => {
+  it('?era=neolithic returns only neolithic events', async () => {
+    const res = await request(app).get('/timeline?era=neolithic')
+    expect(res.status).toBe(200)
+    expect(res.body.events.length).toBeGreaterThan(0)
+    for (const event of res.body.events) {
+      expect(event.era.toLowerCase()).toContain('neolithic')
+    }
+  })
+
+  it('?era=industrial returns only industrial events', async () => {
+    const res = await request(app).get('/timeline?era=industrial')
+    expect(res.status).toBe(200)
+    expect(res.body.events.length).toBeGreaterThan(0)
+    for (const event of res.body.events) {
+      expect(event.era.toLowerCase()).toContain('industrial')
+    }
+  })
+
+  it('?era= filter is case-insensitive', async () => {
+    const lower = await request(app).get('/timeline?era=neolithic')
+    const upper = await request(app).get('/timeline?era=NEOLITHIC')
+    expect(lower.body.total_events).toBe(upper.body.total_events)
+  })
+
+  it('?era=zzznomatch returns 0 events but still 200', async () => {
+    const res = await request(app).get('/timeline?era=zzznomatch')
+    expect(res.status).toBe(200)
+    expect(res.body.total_events).toBe(0)
+    expect(Array.isArray(res.body.events)).toBe(true)
+  })
+
+  it('filtered response includes filters_applied field', async () => {
+    const res = await request(app).get('/timeline?era=roman')
+    expect(res.body).toHaveProperty('filters_applied')
+    expect(res.body.filters_applied.era).toBe('roman')
+  })
+
+  it('unfiltered response does not include filters_applied', async () => {
+    const res = await request(app).get('/timeline')
+    expect(res.body).not.toHaveProperty('filters_applied')
+  })
+})
+
+// ── GET /timeline?after= and ?before= ─────────────────────────────────────────
+
+describe('GET /timeline?after= and ?before= — year range filters', () => {
+  it('?before=0 returns only BCE events (negative years)', async () => {
+    const res = await request(app).get('/timeline?before=0')
+    expect(res.status).toBe(200)
+    expect(res.body.events.length).toBeGreaterThan(0)
+    for (const event of res.body.events) {
+      expect(event.year).toBeLessThan(0)
+    }
+  })
+
+  it('?after=1800 returns only events after 1800 CE', async () => {
+    const res = await request(app).get('/timeline?after=1800')
+    expect(res.status).toBe(200)
+    expect(res.body.events.length).toBeGreaterThan(0)
+    for (const event of res.body.events) {
+      expect(event.year).toBeGreaterThan(1800)
+    }
+  })
+
+  it('?after=-1000&before=1000 returns events between 1000 BCE and 1000 CE', async () => {
+    const res = await request(app).get('/timeline?after=-1000&before=1000')
+    expect(res.status).toBe(200)
+    for (const event of res.body.events) {
+      expect(event.year).toBeGreaterThan(-1000)
+      expect(event.year).toBeLessThan(1000)
+    }
+  })
+
+  it('?after=9000 (future) returns 0 events but 200 status', async () => {
+    const res = await request(app).get('/timeline?after=9000')
+    expect(res.status).toBe(200)
+    expect(res.body.total_events).toBe(0)
+  })
+
+  it('invalid ?after value returns 400', async () => {
+    const res = await request(app).get('/timeline?after=notanumber')
+    expect(res.status).toBe(400)
+    expect(res.body).toHaveProperty('error')
+  })
+
+  it('invalid ?before value returns 400', async () => {
+    const res = await request(app).get('/timeline?before=notanumber')
+    expect(res.status).toBe(400)
+    expect(res.body).toHaveProperty('error')
+  })
+
+  it('?after=1900 filters_applied includes after value as number', async () => {
+    const res = await request(app).get('/timeline?after=1900')
+    expect(res.body.filters_applied.after).toBe(1900)
+  })
+
+  it('filtered results remain in chronological order', async () => {
+    const res = await request(app).get('/timeline?after=1800')
+    const years: number[] = res.body.events.map((e: { year: number }) => e.year)
+    for (let i = 1; i < years.length; i++) {
+      expect(years[i]).toBeGreaterThanOrEqual(years[i - 1])
+    }
+  })
+})
+
+// ── does_this_help invariant ─────────────────────────────────────────────────
+
+describe('GET /timeline — does_this_help invariant', () => {
+  it('does_this_help is false on unfiltered response', async () => {
+    const res = await request(app).get('/timeline')
+    expect(res.body.does_this_help).toBe(false)
+  })
+
+  it('does_this_help is false when ?era filter applied', async () => {
+    const res = await request(app).get('/timeline?era=medieval')
+    expect(res.body.does_this_help).toBe(false)
+  })
+
+  it('does_this_help is false when ?after filter applied', async () => {
+    const res = await request(app).get('/timeline?after=1800')
+    expect(res.body.does_this_help).toBe(false)
+  })
+
+  it('does_this_help is false even when 0 events match', async () => {
+    const res = await request(app).get('/timeline?era=zzznomatch')
+    expect(res.body.does_this_help).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `GET /timeline` returning 20 milestones in the history of cheese from 8000 BCE to the present, each annotated with its `significance` and a `verdict` on why it represents a step in the wrong direction
- Supports optional query filters: `?era=` (substring match), `?after=` and `?before=` (year range, negative integers for BCE)
- `does_this_help: false` is present on every response — filtered, unfiltered, or returning zero events
- Filtered responses include a `filters_applied` field; unfiltered responses do not

## Timeline milestones (20 total)

| Year | Era | Event |
|------|-----|-------|
| −8000 | Neolithic | First evidence of cheese-making — pottery residue, Kuyavia, Poland |
| −5500 | Neolithic / Copper Age | Clay cheese strainers found across Central Europe — not an isolated incident |
| −3000 | Ancient Egypt | Cheese in tomb murals; 3,200-year-old cheese found in Saqqara |
| −2000 | Bronze Age | Sumerian cuneiform records cheese trade across Mesopotamia |
| −800 | Ancient Greece | Homer's Odyssey: the Cyclops makes cheese. The Cyclops is the villain. |
| −100 | Roman Empire | Roman soldiers issued cheese rations; empire-wide trade routes |
| 1115 | Medieval Europe | First documented reference to Gruyère |
| 1170 | Medieval England | Henry II buys 10,240 lbs of Cheddar for the royal court |
| 1200 | Medieval Europe | Monks deliberately cultivate mold cultures; Brie, Munster, Port Salut refined |
| 1620 | Early Modern | Cheddar first mentioned by name in English records |
| 1815 | Industrial Revolution | First cooperative cheese factory, Bern, Switzerland |
| 1851 | Industrial America | Jesse Williams opens first American cheese factory, Rome, NY |
| 1910 | Early 20th Century | Kraft patents processed cheese |
| 1928 | Early 20th Century | Velveeta: not legally cheese under FDA standards; sold as cheese anyway |
| 1953 | Post-War Industrial | US government begins purchasing surplus cheese; limestone cave storage begins |
| 1981 | Late 20th Century | Reagan distributes 30M lbs of government cheese to low-income Americans |
| 1992 | Late 20th Century | EU establishes Protected Designation of Origin framework for 200+ cheeses |
| 2002 | 21st Century | EU grants Feta PDO; Denmark and Germany sue in European Court of Justice and lose |
| 2020 | 21st Century | Global production: 22 million metric tonnes/year; market: $120B+ |
| 2024 | Present | Market projected to exceed $200B; cheese now has tourism, TV, and subscription boxes |

## Test plan

- [x] 42 assertions in `src/tests/timeline.test.ts`
- [x] Baseline: 200 status, all required top-level fields, `does_this_help: false`, at least 15 events
- [x] Chronological ordering enforced on full and filtered results
- [x] Event shape: all required fields, integer year, non-empty strings, `cheese_implicated` is null or string
- [x] Content spot-checks: Neolithic event, Roman era, industrial era, processed cheese entry, 21st-century event
- [x] `?era=` filter: case-insensitive, filters correctly, zero-result returns 200, `filters_applied` field present
- [x] `?after=`/`?before=` filters: BCE events, post-1800 events, combined range, future year = 0 results
- [x] Invalid filter values return 400 with error message
- [x] `does_this_help: false` invariant holds across all filter states including zero-result queries
- [x] Schema drift test automatically verified `GET /timeline` appears in `GET /api`
- [x] All 478 tests pass

Closes #98