### PR TITLE
[cheese-hater] Add GET /severity/:tier — browse cheeses by threat level

### DIFF
--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -644,6 +644,48 @@ export const ENDPOINTS = [
       why_not: 'Understanding how we arrived here does not un-arrive us. The cheese exists. The timeline explains why. It does not excuse it.',
     },
   },
+  {
+    method: 'GET',
+    path: '/severity',
+    description: 'Returns the Cheese Threat Advisory Scale — all three tiers listed with counts, score ranges, threat levels, and descriptions. Use GET /severity/:tier to see the cheeses in each tier.',
+    parameters: [],
+    example_request: 'GET /severity',
+    example_response: {
+      title: 'The Cheese Threat Advisory Scale',
+      tiers: [
+        { tier: 'catastrophic', label: 'CATASTROPHIC', score_range: '0.0 – 0.99', threat_level: 'Immediate. No mitigation available.', count: 4, worst_in_tier: 'Casu Martzu' },
+        { tier: 'revolting',    label: 'REVOLTING',    score_range: '1.0 – 1.99', threat_level: 'High. Avoidance strongly recommended.', count: 10, worst_in_tier: 'Blue Cheese' },
+        { tier: 'condemned',    label: 'CONDEMNED',    score_range: '2.0 and above', threat_level: 'Moderate. Do not be deceived by comparatively higher scores.', count: 7, worst_in_tier: 'Provolone' },
+      ],
+      total_cheeses_assessed: 21,
+    },
+  },
+  {
+    method: 'GET',
+    path: '/severity/:tier',
+    description: 'Returns all cheeses at a given threat level, ranked from worst to least-worst within the tier. Valid tiers: catastrophic (score < 1.0), revolting (1.0–1.99), condemned (2.0+). Invalid tier names return 400 with the valid tier list and threat descriptions.',
+    parameters: [
+      {
+        name: 'tier',
+        location: 'path',
+        type: 'string',
+        required: true,
+        description: 'The severity tier to browse. Must be exactly one of: catastrophic, revolting, condemned. Case-insensitive.',
+      },
+    ],
+    example_request: 'GET /severity/catastrophic',
+    example_response: {
+      tier: 'catastrophic',
+      label: 'CATASTROPHIC',
+      score_range: '0.0 – 0.99',
+      threat_level: 'Immediate. No mitigation available.',
+      cheeses: [
+        { rank: 1, cheese: 'Casu Martzu', score: 0.125, severity_tier: 'catastrophic', verdict: 'CATASTROPHIC', why_it_wins: 'Contains live maggots…' },
+        { rank: 2, cheese: 'Blue Cheese', score: 0.625, severity_tier: 'catastrophic', verdict: 'CATASTROPHIC', why_it_wins: 'Deliberately cultivated mold…' },
+      ],
+      total: 4,
+    },
+  },
 ]
 
 router.get('/', (_req, res) => {

--- a/src/routes/severity.ts
+++ b/src/routes/severity.ts
@@ -1,0 +1,122 @@
+/**
+ * GET /severity/:tier — browse all cheeses at a given threat level.
+ *
+ * Valid tiers (the Cheese Threat Advisory Scale):
+ *   catastrophic — score < 1.0. The worst of all possible cheeses.
+ *   revolting    — score 1.0–1.99. Bad in every measurable way.
+ *   condemned    — score 2.0+. Still cheese. Still guilty.
+ *
+ * Returns cheeses in the tier ranked ascending by score (worst first).
+ * Invalid tier names return 400 with the valid tier list and descriptions.
+ *
+ * GET /severity — lists all tiers with counts and descriptions.
+ */
+import { Router, Request, Response } from 'express'
+import { ratings } from '../lib/cheeseHater'
+import { WHY_IT_WINS, VERDICT_TO_TIER, defaultWhyItWins } from '../lib/worstAnnotations'
+
+const router = Router()
+
+// ── Tier definitions (the Cheese Threat Advisory Scale) ───────────────────────
+
+const TIER_ADVISORY: Record<string, { label: string; score_range: string; description: string; threat_level: string }> = {
+  catastrophic: {
+    label: 'CATASTROPHIC',
+    score_range: '0.0 – 0.99',
+    description: 'The apex of dairy failure. These cheeses represent the full deployment of everything wrong with fermented milk. Maggots, banned-from-public-transport odours, deliberately cultivated mold in quantities that exceed all reasonable standards. Encountering one of these cheeses is a threat to the immediate environment.',
+    threat_level: 'Immediate. No mitigation available.',
+  },
+  revolting: {
+    label: 'REVOLTING',
+    score_range: '1.0 – 1.99',
+    description: 'Serious and sustained dairy offenses. These cheeses are not catastrophic only because the catastrophic tier exists. They are mold-ripened, bacteria-colonised, or structured in ways that no food should be structured. They have convinced significant portions of the population that they are acceptable. They are not.',
+    threat_level: 'High. Avoidance strongly recommended.',
+  },
+  condemned: {
+    label: 'CONDEMNED',
+    score_range: '2.0 and above',
+    description: 'The mildest tier of a bad thing is still a bad thing. Condemned cheeses score highest on this scale because they are marginally less awful than the tiers above. They are still fermented animal milk products. They are still cheese. The gap between condemned and revolting is a matter of degree. The verdict is the same.',
+    threat_level: 'Moderate. Do not be deceived by comparatively higher scores.',
+  },
+}
+
+const VALID_TIERS = new Set(Object.keys(TIER_ADVISORY))
+
+// Build the full ranked dataset once
+function buildAllRanked() {
+  return [...ratings]
+    .sort((a, b) => a.score - b.score)
+    .map((r, idx) => ({
+      rank: idx + 1,
+      cheese: r.name,
+      score: r.score,
+      severity_tier: VERDICT_TO_TIER[r.verdict] ?? r.verdict.toLowerCase(),
+      verdict: r.verdict,
+      why_it_wins: WHY_IT_WINS[r.name] ?? defaultWhyItWins(r.name, r.score),
+    }))
+}
+
+// ── GET /severity — list all tiers with counts ────────────────────────────────
+
+router.get('/', (_req: Request, res: Response) => {
+  const all = buildAllRanked()
+
+  const tierSummary = Object.entries(TIER_ADVISORY).map(([key, advisory]) => {
+    const cheeses = all.filter(e => e.severity_tier === key)
+    return {
+      tier: key,
+      label: advisory.label,
+      score_range: advisory.score_range,
+      threat_level: advisory.threat_level,
+      description: advisory.description,
+      count: cheeses.length,
+      worst_in_tier: cheeses[0]?.cheese ?? null,
+    }
+  })
+
+  res.json({
+    title: 'The Cheese Threat Advisory Scale',
+    description: 'All known cheeses classified by severity. The scale runs from condemned (bad) through revolting (worse) to catastrophic (the worst). Every tier is indefensible. The scale exists only to communicate the degree of indefensibility.',
+    tiers: tierSummary,
+    total_cheeses_assessed: all.length,
+    note: 'Use GET /severity/:tier to see all cheeses at a given threat level. Valid tiers: catastrophic, revolting, condemned.',
+  })
+})
+
+// ── GET /severity/:tier — cheeses at a given threat level ────────────────────
+
+router.get('/:tier', (req: Request, res: Response) => {
+  const raw = req.params.tier.trim().toLowerCase()
+
+  if (!VALID_TIERS.has(raw)) {
+    res.status(400).json({
+      error: `Unknown severity tier: "${req.params.tier}".`,
+      valid_tiers: {
+        catastrophic: `${TIER_ADVISORY.catastrophic.score_range} — ${TIER_ADVISORY.catastrophic.threat_level}`,
+        revolting:    `${TIER_ADVISORY.revolting.score_range} — ${TIER_ADVISORY.revolting.threat_level}`,
+        condemned:    `${TIER_ADVISORY.condemned.score_range} — ${TIER_ADVISORY.condemned.threat_level}`,
+      },
+      note: 'The Cheese Threat Advisory Scale has three levels. All three are bad. Pick one.',
+    })
+    return
+  }
+
+  const advisory = TIER_ADVISORY[raw]
+  const all = buildAllRanked()
+  const inTier = all
+    .filter(e => e.severity_tier === raw)
+    .map((e, idx) => ({ ...e, rank: idx + 1 }))   // re-rank within tier
+
+  res.json({
+    tier: raw,
+    label: advisory.label,
+    score_range: advisory.score_range,
+    threat_level: advisory.threat_level,
+    description: advisory.description,
+    cheeses: inTier,
+    total: inTier.length,
+    note: `All ${inTier.length} cheeses in this tier have been assessed, found guilty, and ranked accordingly. The ranking is from most to least terrible within the tier.`,
+  })
+})
+
+export default router

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import worstRouter from './routes/worst'
 import searchRouter from './routes/search'
 import etymologyRouter from './routes/etymology'
 import timelineRouter from './routes/timeline'
+import severityRouter from './routes/severity'
 import { generateExplorerHtml } from './lib/explorerHtml'
 
 const app = express()
@@ -68,6 +69,8 @@ app.get('/', (req, res) => {
       'GET /etymology/:cheese': 'Get the name origin of any cheese. Always concludes: does_this_help: false',
       'GET /etymology':         'List all cheeses with documented etymologies',
       'GET /timeline':          'Chronological history of cheese — 20 milestones, each worse than the last. Supports ?era, ?after, ?before filters',
+      'GET /severity':          'The Cheese Threat Advisory Scale — all tiers listed with counts and descriptions',
+      'GET /severity/:tier':    'Browse all cheeses at a given threat level (catastrophic / revolting / condemned)',
       'GET /roast':             'Get today\'s daily cheese roast — a different cheese condemned each day',
       'GET /roast/history':     'Browse past N days of roasted cheeses (default 7, max 30)',
       'GET /roast/versus':      'Pit two cheeses against each other — declare the worse offender',
@@ -116,6 +119,9 @@ app.use('/etymology', etymologyRouter)
 // GET /timeline — chronological history of cheese and why each century made things worse
 app.use('/timeline', timelineRouter)
 
+// GET /severity/:tier — browse cheeses by threat level (catastrophic / revolting / condemned)
+app.use('/severity', severityRouter)
+
 // GET /api — endpoint discovery: all routes, parameters, and example responses
 app.use('/api', apiRouter)
 
@@ -142,6 +148,8 @@ app.use((_req, res) => {
       'GET /etymology',
       'GET /etymology/:cheese',
       'GET /timeline',
+      'GET /severity',
+      'GET /severity/:tier',
       'GET /roast',
       'GET /roast/history',
       'GET /roast/versus',

--- a/src/tests/severity.test.ts
+++ b/src/tests/severity.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for GET /severity/:tier and GET /severity.
+ *
+ * The Cheese Threat Advisory Scale: catastrophic, revolting, condemned.
+ * All tiers are bad. The scale exists only to communicate the degree of
+ * badness. Every cheese on every tier is still cheese.
+ */
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import app from '../server'
+
+const VALID_TIERS = ['catastrophic', 'revolting', 'condemned'] as const
+const CHEESE_ENTRY_FIELDS = ['rank', 'cheese', 'score', 'severity_tier', 'verdict', 'why_it_wins'] as const
+
+// ── GET /severity — list all tiers ────────────────────────────────────────────
+
+describe('GET /severity — tier listing', () => {
+  it('returns 200', async () => {
+    const res = await request(app).get('/severity')
+    expect(res.status).toBe(200)
+  })
+
+  it('has a title field', async () => {
+    const res = await request(app).get('/severity')
+    expect(typeof res.body.title).toBe('string')
+    expect(res.body.title.length).toBeGreaterThan(0)
+  })
+
+  it('tiers is an array of exactly 3 entries', async () => {
+    const res = await request(app).get('/severity')
+    expect(Array.isArray(res.body.tiers)).toBe(true)
+    expect(res.body.tiers.length).toBe(3)
+  })
+
+  it('each tier entry has: tier, label, score_range, threat_level, description, count, worst_in_tier', async () => {
+    const res = await request(app).get('/severity')
+    for (const entry of res.body.tiers) {
+      expect(entry).toHaveProperty('tier')
+      expect(entry).toHaveProperty('label')
+      expect(entry).toHaveProperty('score_range')
+      expect(entry).toHaveProperty('threat_level')
+      expect(entry).toHaveProperty('description')
+      expect(entry).toHaveProperty('count')
+      expect(entry).toHaveProperty('worst_in_tier')
+    }
+  })
+
+  it('all three valid tiers are present', async () => {
+    const res = await request(app).get('/severity')
+    const tierNames: string[] = res.body.tiers.map((t: { tier: string }) => t.tier)
+    for (const tier of VALID_TIERS) {
+      expect(tierNames).toContain(tier)
+    }
+  })
+
+  it('total_cheeses_assessed is a positive integer', async () => {
+    const res = await request(app).get('/severity')
+    expect(Number.isInteger(res.body.total_cheeses_assessed)).toBe(true)
+    expect(res.body.total_cheeses_assessed).toBeGreaterThan(0)
+  })
+
+  it('sum of tier counts equals total_cheeses_assessed', async () => {
+    const res = await request(app).get('/severity')
+    const sum = res.body.tiers.reduce((acc: number, t: { count: number }) => acc + t.count, 0)
+    expect(sum).toBe(res.body.total_cheeses_assessed)
+  })
+
+  it('catastrophic tier has at least 1 cheese', async () => {
+    const res = await request(app).get('/severity')
+    const catastrophic = res.body.tiers.find((t: { tier: string }) => t.tier === 'catastrophic')
+    expect(catastrophic.count).toBeGreaterThan(0)
+  })
+
+  it('worst_in_tier is a non-null string for all tiers', async () => {
+    const res = await request(app).get('/severity')
+    for (const entry of res.body.tiers) {
+      expect(typeof entry.worst_in_tier).toBe('string')
+      expect(entry.worst_in_tier.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+// ── GET /severity/:tier — valid tiers ─────────────────────────────────────────
+
+describe('GET /severity/:tier — valid tiers return 200', () => {
+  for (const tier of VALID_TIERS) {
+    it(`returns 200 for tier "${tier}"`, async () => {
+      const res = await request(app).get(`/severity/${tier}`)
+      expect(res.status).toBe(200)
+    })
+  }
+})
+
+describe('GET /severity/:tier — response shape', () => {
+  it('has tier, label, score_range, threat_level, description, cheeses, total, note', async () => {
+    const res = await request(app).get('/severity/catastrophic')
+    expect(res.body).toHaveProperty('tier')
+    expect(res.body).toHaveProperty('label')
+    expect(res.body).toHaveProperty('score_range')
+    expect(res.body).toHaveProperty('threat_level')
+    expect(res.body).toHaveProperty('description')
+    expect(res.body).toHaveProperty('cheeses')
+    expect(res.body).toHaveProperty('total')
+    expect(res.body).toHaveProperty('note')
+  })
+
+  it('cheeses is an array', async () => {
+    const res = await request(app).get('/severity/catastrophic')
+    expect(Array.isArray(res.body.cheeses)).toBe(true)
+  })
+
+  it('total matches cheeses array length', async () => {
+    const res = await request(app).get('/severity/revolting')
+    expect(res.body.total).toBe(res.body.cheeses.length)
+  })
+
+  it('each cheese entry has all required fields', async () => {
+    const res = await request(app).get('/severity/condemned')
+    for (const entry of res.body.cheeses) {
+      for (const field of CHEESE_ENTRY_FIELDS) {
+        expect(entry, `Missing field "${field}" in cheese entry`).toHaveProperty(field)
+      }
+    }
+  })
+
+  it('tier field in response matches the requested tier', async () => {
+    for (const tier of VALID_TIERS) {
+      const res = await request(app).get(`/severity/${tier}`)
+      expect(res.body.tier).toBe(tier)
+    }
+  })
+})
+
+// ── GET /severity/:tier — tier membership correctness ─────────────────────────
+
+describe('GET /severity/:tier — tier membership', () => {
+  it('all catastrophic cheeses have severity_tier: "catastrophic"', async () => {
+    const res = await request(app).get('/severity/catastrophic')
+    for (const entry of res.body.cheeses) {
+      expect(entry.severity_tier).toBe('catastrophic')
+    }
+  })
+
+  it('all revolting cheeses have severity_tier: "revolting"', async () => {
+    const res = await request(app).get('/severity/revolting')
+    for (const entry of res.body.cheeses) {
+      expect(entry.severity_tier).toBe('revolting')
+    }
+  })
+
+  it('all condemned cheeses have severity_tier: "condemned"', async () => {
+    const res = await request(app).get('/severity/condemned')
+    for (const entry of res.body.cheeses) {
+      expect(entry.severity_tier).toBe('condemned')
+    }
+  })
+
+  it('catastrophic scores are all < 1.0', async () => {
+    const res = await request(app).get('/severity/catastrophic')
+    for (const entry of res.body.cheeses) {
+      expect(entry.score).toBeLessThan(1.0)
+    }
+  })
+
+  it('revolting scores are all between 1.0 and 1.99', async () => {
+    const res = await request(app).get('/severity/revolting')
+    for (const entry of res.body.cheeses) {
+      expect(entry.score).toBeGreaterThanOrEqual(1.0)
+      expect(entry.score).toBeLessThan(2.0)
+    }
+  })
+
+  it('condemned scores are all >= 2.0', async () => {
+    const res = await request(app).get('/severity/condemned')
+    for (const entry of res.body.cheeses) {
+      expect(entry.score).toBeGreaterThanOrEqual(2.0)
+    }
+  })
+
+  it('cheeses are ranked ascending by score within each tier (worst first)', async () => {
+    for (const tier of VALID_TIERS) {
+      const res = await request(app).get(`/severity/${tier}`)
+      const scores: number[] = res.body.cheeses.map((e: { score: number }) => e.score)
+      for (let i = 1; i < scores.length; i++) {
+        expect(scores[i]).toBeGreaterThanOrEqual(scores[i - 1])
+      }
+    }
+  })
+
+  it('ranks are sequential starting from 1', async () => {
+    const res = await request(app).get('/severity/revolting')
+    const ranks: number[] = res.body.cheeses.map((e: { rank: number }) => e.rank)
+    ranks.forEach((rank, idx) => expect(rank).toBe(idx + 1))
+  })
+})
+
+// ── GET /severity/:tier — cross-tier consistency ──────────────────────────────
+
+describe('GET /severity — cross-tier consistency', () => {
+  it('no cheese appears in more than one tier', async () => {
+    const seenNames = new Set<string>()
+    for (const tier of VALID_TIERS) {
+      const res = await request(app).get(`/severity/${tier}`)
+      for (const entry of res.body.cheeses) {
+        expect(seenNames.has(entry.cheese), `"${entry.cheese}" appears in multiple tiers`).toBe(false)
+        seenNames.add(entry.cheese)
+      }
+    }
+  })
+
+  it('total across all tiers matches GET /severity total_cheeses_assessed', async () => {
+    const listRes = await request(app).get('/severity')
+    let total = 0
+    for (const tier of VALID_TIERS) {
+      const res = await request(app).get(`/severity/${tier}`)
+      total += res.body.total
+    }
+    expect(total).toBe(listRes.body.total_cheeses_assessed)
+  })
+})
+
+// ── GET /severity/:tier — case insensitivity ──────────────────────────────────
+
+describe('GET /severity/:tier — case insensitivity', () => {
+  it('CATASTROPHIC (uppercase) returns the catastrophic tier', async () => {
+    const res = await request(app).get('/severity/CATASTROPHIC')
+    expect(res.status).toBe(200)
+    expect(res.body.tier).toBe('catastrophic')
+  })
+
+  it('REVOLTING (uppercase) returns the revolting tier', async () => {
+    const res = await request(app).get('/severity/REVOLTING')
+    expect(res.status).toBe(200)
+    expect(res.body.tier).toBe('revolting')
+  })
+})
+
+// ── GET /severity/:tier — invalid tier → 400 ─────────────────────────────────
+
+describe('GET /severity/:tier — invalid tiers return 400', () => {
+  it('unknown tier returns 400', async () => {
+    const res = await request(app).get('/severity/mild')
+    expect(res.status).toBe(400)
+  })
+
+  it('400 response has an error field', async () => {
+    const res = await request(app).get('/severity/disgusting')
+    expect(res.body).toHaveProperty('error')
+  })
+
+  it('400 response includes valid_tiers field', async () => {
+    const res = await request(app).get('/severity/offensive')
+    expect(res.body).toHaveProperty('valid_tiers')
+  })
+
+  it('valid_tiers lists all three tiers', async () => {
+    const res = await request(app).get('/severity/terrible')
+    const listed = Object.keys(res.body.valid_tiers)
+    for (const tier of VALID_TIERS) {
+      expect(listed).toContain(tier)
+    }
+  })
+
+  it('completely invalid string returns 400', async () => {
+    const res = await request(app).get('/severity/notarealthing')
+    expect(res.status).toBe(400)
+  })
+})
+
+// ── GET /api schema coverage ──────────────────────────────────────────────────
+
+describe('GET /api — schema includes severity endpoints', () => {
+  it('GET /api lists /severity', async () => {
+    const res = await request(app).get('/api')
+    const paths: string[] = res.body.endpoints.map((e: { path: string }) => e.path)
+    expect(paths).toContain('/severity')
+  })
+
+  it('GET /api lists /severity/:tier', async () => {
+    const res = await request(app).get('/api')
+    const paths: string[] = res.body.endpoints.map((e: { path: string }) => e.path)
+    expect(paths).toContain('/severity/:tier')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `GET /severity` — the Cheese Threat Advisory Scale: all three tiers listed with counts, score ranges, threat levels, and descriptions
- Adds `GET /severity/:tier` — all cheeses at a given threat level, ranked ascending by score (worst first within the tier)
- Invalid tier names return 400 with the full `valid_tiers` map and threat-level descriptions — in character as a cheese advisory scale
- Tier matching is case-insensitive (`CATASTROPHIC` works)

## The Cheese Threat Advisory Scale

| Tier | Score range | Threat level |
|------|-------------|--------------|
| `catastrophic` | 0.0 – 0.99 | Immediate. No mitigation available. |
| `revolting` | 1.0 – 1.99 | High. Avoidance strongly recommended. |
| `condemned` | 2.0+ | Moderate. Do not be deceived by comparatively higher scores. |

## Implementation notes

- Reuses existing `cheese-ratings.json` data via the `cheeseHater` lib and `WHY_IT_WINS` / `VERDICT_TO_TIER` / `defaultWhyItWins` from `worstAnnotations.ts` — no new data files needed
- Each cheese entry includes: `rank`, `cheese`, `score`, `severity_tier`, `verdict`, `why_it_wins`
- Ranks are re-numbered 1..N within the tier (not global rank)
- `GET /severity` includes `worst_in_tier` for each tier and `total_cheeses_assessed` (sum of all tier counts)

## Test plan

- [x] 36 assertions in `src/tests/severity.test.ts`
- [x] `GET /severity`: 200, 3 tiers, all fields present, tier count sum = total_cheeses_assessed
- [x] `GET /severity/:tier`: 200 for all three valid tiers, all cheese entry fields present
- [x] Tier membership: catastrophic scores < 1.0, revolting 1.0–1.99, condemned ≥ 2.0
- [x] Rankings are ascending by score (worst first) and sequential from 1
- [x] No cheese appears in more than one tier; cross-tier totals match `/severity` count
- [x] Case-insensitive: `CATASTROPHIC` and `REVOLTING` resolve correctly
- [x] Invalid tier → 400 with `error` and `valid_tiers` fields listing all three tiers
- [x] Schema drift: `GET /api` lists both `/severity` and `/severity/:tier`
- [x] All 514 tests pass (schema-drift test continues to pass)

Closes #104