### PR TITLE
[cheese-hater] Add next/prev hypermedia links to all paginated list endpoints

### DIFF
--- a/src/lib/paginate.ts
+++ b/src/lib/paginate.ts
@@ -42,3 +42,29 @@ export function applyPagination<T>(arr: T[], params: PaginationParams): { page: 
   const page = arr.slice(params.offset, params.offset + params.limit);
   return { page, total, limit: params.limit, offset: params.offset, has_more: params.offset + params.limit < total };
 }
+
+// Build next/prev hypermedia link strings for paginated responses.
+// extraParams: any other query params to preserve (e.g. { q: 'mold', tier: 'critical' })
+// Returns null for next when on the last page; null for prev when at offset 0.
+export function buildLinks(
+  basePath: string,
+  params: PaginationParams,
+  total: number,
+  extraParams: Record<string, string> = {}
+): { next: string | null; prev: string | null } {
+  const has_more = params.offset + params.limit < total;
+
+  const qs = (offset: number): string => {
+    const p = new URLSearchParams({
+      ...extraParams,
+      limit: String(params.limit),
+      offset: String(offset),
+    });
+    return `${basePath}?${p.toString()}`;
+  };
+
+  return {
+    next: has_more ? qs(params.offset + params.limit) : null,
+    prev: params.offset > 0 ? qs(Math.max(0, params.offset - params.limit)) : null,
+  };
+}

--- a/src/routes/etymology.ts
+++ b/src/routes/etymology.ts
@@ -7,7 +7,7 @@
  */
 import { Router, Request, Response } from 'express'
 import etymologiesRaw from '../data/cheese-etymologies.json'
-import { parsePagination, applyPagination } from '../lib/paginate'
+import { parsePagination, applyPagination, buildLinks } from '../lib/paginate'
 
 interface Etymology {
   cheese: string
@@ -105,6 +105,7 @@ router.get('/', (req: Request, res: Response) => {
   }))
 
   const { page, total, limit, offset, has_more } = applyPagination(allEtymologies, params)
+  const { next, prev } = buildLinks('/etymology', params, total)
 
   res.json({
     documented_cheeses: page,
@@ -112,6 +113,8 @@ router.get('/', (req: Request, res: Response) => {
     limit,
     offset,
     has_more,
+    next,
+    prev,
     does_this_help: false,
     why_not: 'Listing cheeses by their name origins does not rehabilitate any of them. Every cheese on this list remains indefensible.',
     usage: 'GET /etymology/:cheese — e.g. GET /etymology/brie',

--- a/src/routes/facts.ts
+++ b/src/routes/facts.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response } from 'express'
 import { getRandomFact, facts } from '../lib/cheeseHater'
-import { parsePagination, applyPagination } from '../lib/paginate'
+import { parsePagination, applyPagination, buildLinks } from '../lib/paginate'
 
 const router = Router()
 
@@ -109,6 +109,9 @@ router.get('/search', (req: Request, res: Response) => {
     }))
 
   const { page, total, limit, offset, has_more } = applyPagination(allResults, params)
+  const extraParams: Record<string, string> = { q: String(rawQ).trim() }
+  if (categoryFilter) extraParams.category = categoryFilter
+  const { next, prev } = buildLinks('/facts/search', params, total, extraParams)
 
   res.json({
     query: rawQ.trim(),
@@ -118,6 +121,8 @@ router.get('/search', (req: Request, res: Response) => {
     limit,
     offset,
     has_more,
+    next,
+    prev,
     note: total > 0
       ? 'Every fact is damning. The query only determines which facts are most immediately relevant.'
       : 'No facts matched this query. All cheese remains indefensible regardless.',
@@ -141,12 +146,15 @@ router.get('/all', (req: Request, res: Response) => {
   }))
 
   const { page, total, limit, offset, has_more } = applyPagination(allFacts, params)
+  const { next, prev } = buildLinks('/facts/all', params, total)
 
   res.json({
     total,
     limit,
     offset,
     has_more,
+    next,
+    prev,
     facts: page,
     note: 'Every fact is sourced. Every fact is damning. Cheese is indefensible.',
   })

--- a/src/routes/severity.ts
+++ b/src/routes/severity.ts
@@ -15,7 +15,7 @@
 import { Router, Request, Response } from 'express'
 import { ratings } from '../lib/cheeseHater'
 import { WHY_IT_WINS, VERDICT_TO_TIER, defaultWhyItWins } from '../lib/worstAnnotations'
-import { parsePagination, applyPagination } from '../lib/paginate'
+import { parsePagination, applyPagination, buildLinks } from '../lib/paginate'
 
 const router = Router()
 
@@ -194,6 +194,7 @@ router.get('/:tier', (req: Request, res: Response) => {
     .map((e, idx) => ({ ...e, rank: idx + 1 }))   // re-rank within tier
 
   const { page, total, limit, offset, has_more } = applyPagination(inTier, params)
+  const { next, prev } = buildLinks(`/severity/${raw}`, params, total)
 
   res.json({
     tier: raw,
@@ -210,6 +211,8 @@ router.get('/:tier', (req: Request, res: Response) => {
     limit,
     offset,
     has_more,
+    next,
+    prev,
     note: `All ${total} cheeses in this tier have been assessed, found guilty, and ranked accordingly. The ranking is from most to least terrible within the tier.`,
   })
 })

--- a/src/routes/timeline.ts
+++ b/src/routes/timeline.ts
@@ -16,7 +16,7 @@
  */
 import { Router, Request, Response } from 'express'
 import timelineRaw from '../data/cheese-timeline.json'
-import { parsePagination, applyPagination } from '../lib/paginate'
+import { parsePagination, applyPagination, buildLinks } from '../lib/paginate'
 
 interface TimelineEvent {
   year: number
@@ -88,6 +88,11 @@ router.get('/', (req: Request, res: Response) => {
   if (beforeYear !== null) filtersApplied.before = beforeYear
 
   const { page, total, limit, offset, has_more } = applyPagination(events, params)
+  const extraParams: Record<string, string> = {}
+  if (era && typeof era === 'string') extraParams.era = era
+  if (afterYear !== null) extraParams.after = String(afterYear)
+  if (beforeYear !== null) extraParams.before = String(beforeYear)
+  const { next, prev } = buildLinks('/timeline', params, total, extraParams)
 
   res.json({
     title: 'A History of Cheese: How We Got Here and Why It Did Not Have to Be This Way',
@@ -97,6 +102,8 @@ router.get('/', (req: Request, res: Response) => {
     limit,
     offset,
     has_more,
+    next,
+    prev,
     ...(isFiltered && total === 0
       ? { note: 'No events match the given filters. The cheese persists regardless.' }
       : {}),

--- a/src/routes/worst.ts
+++ b/src/routes/worst.ts
@@ -89,6 +89,14 @@ router.get('/', (req: Request, res: Response) => {
   const result = limit !== null ? afterOffset.slice(0, limit) : afterOffset
   const has_more = offset + result.length < reranked.length
 
+  // next/prev links — only defined when a limit is set (otherwise the full list is returned)
+  const worstNext = (limit !== null && has_more)
+    ? `/worst?${new URLSearchParams({ ...(tier ? { tier } : {}), limit: String(limit), offset: String(offset + limit) })}`
+    : null
+  const worstPrev = (limit !== null && offset > 0)
+    ? `/worst?${new URLSearchParams({ ...(tier ? { tier } : {}), limit: String(limit), offset: String(Math.max(0, offset - limit)) })}`
+    : null
+
   res.json({
     ranked: result,
     total: result.length,
@@ -97,6 +105,8 @@ router.get('/', (req: Request, res: Response) => {
     ...(limit !== null ? { limit } : {}),
     offset,
     has_more,
+    next: worstNext,
+    prev: worstPrev,
     note: 'Ranked from most terrible to least. The least terrible cheese on this list is still cheese.',
   })
 })

--- a/src/tests/pagination.test.ts
+++ b/src/tests/pagination.test.ts
@@ -362,3 +362,140 @@ describe('GET /severity/:tier — pagination', () => {
     expect(res.body).toHaveProperty('error')
   })
 })
+
+// ── Hypermedia links (next / prev) ────────────────────────────────────────────
+
+describe('next / prev links — GET /facts/all', () => {
+  it('first page: next is a string, prev is null', async () => {
+    const res = await request(app).get('/facts/all?limit=3&offset=0')
+    expect(res.status).toBe(200)
+    expect(typeof res.body.next).toBe('string')
+    expect(res.body.prev).toBeNull()
+    expect(res.body.next).toContain('/facts/all')
+    expect(res.body.next).toContain('offset=3')
+  })
+
+  it('middle page: next is a string, prev is a string', async () => {
+    const res = await request(app).get('/facts/all?limit=3&offset=3')
+    expect(res.status).toBe(200)
+    expect(typeof res.body.next).toBe('string')
+    expect(typeof res.body.prev).toBe('string')
+    expect(res.body.prev).toContain('offset=0')
+    expect(res.body.next).toContain('offset=6')
+  })
+
+  it('last page: next is null, prev is a string', async () => {
+    // fetch total first, then jump to a page that will be the last
+    const all = await request(app).get('/facts/all?limit=100')
+    const total: number = all.body.total
+    const offset = total - 1
+    const res = await request(app).get(`/facts/all?limit=3&offset=${offset}`)
+    expect(res.status).toBe(200)
+    expect(res.body.next).toBeNull()
+    expect(typeof res.body.prev).toBe('string')
+  })
+
+  it('out-of-range offset: next is null, prev is a string', async () => {
+    const res = await request(app).get('/facts/all?limit=5&offset=9999')
+    expect(res.status).toBe(200)
+    expect(res.body.next).toBeNull()
+    expect(typeof res.body.prev).toBe('string')
+  })
+
+  it('next link contains correct limit param', async () => {
+    const res = await request(app).get('/facts/all?limit=7&offset=0')
+    expect(res.status).toBe(200)
+    if (res.body.next !== null) {
+      expect(res.body.next).toContain('limit=7')
+    }
+  })
+})
+
+describe('next / prev links — GET /timeline', () => {
+  it('first page has next, no prev', async () => {
+    const res = await request(app).get('/timeline?limit=3&offset=0')
+    expect(res.status).toBe(200)
+    expect(typeof res.body.next).toBe('string')
+    expect(res.body.prev).toBeNull()
+  })
+
+  it('next link preserves era filter', async () => {
+    const res = await request(app).get('/timeline?limit=1&offset=0&era=ancient')
+    expect(res.status).toBe(200)
+    if (res.body.next !== null) {
+      expect(res.body.next).toContain('era=ancient')
+    }
+  })
+})
+
+describe('next / prev links — GET /etymology', () => {
+  it('first page: next is a string (10 cheeses, limit=3)', async () => {
+    const res = await request(app).get('/etymology?limit=3&offset=0')
+    expect(res.status).toBe(200)
+    expect(typeof res.body.next).toBe('string')
+    expect(res.body.prev).toBeNull()
+    expect(res.body.next).toContain('/etymology')
+    expect(res.body.next).toContain('offset=3')
+  })
+
+  it('offset past end: next null, prev present', async () => {
+    const res = await request(app).get('/etymology?limit=3&offset=9999')
+    expect(res.status).toBe(200)
+    expect(res.body.next).toBeNull()
+    expect(typeof res.body.prev).toBe('string')
+  })
+})
+
+describe('next / prev links — GET /severity/:tier', () => {
+  it('first page of catastrophic tier: next or null depending on count, prev null', async () => {
+    const res = await request(app).get('/severity/catastrophic?limit=1&offset=0')
+    expect(res.status).toBe(200)
+    expect(res.body.prev).toBeNull()
+    // next is string if more items exist, null if only one in tier
+    expect(res.body.next === null || typeof res.body.next === 'string').toBe(true)
+  })
+})
+
+describe('next / prev links — GET /facts/search', () => {
+  it('search results: next link preserves q param', async () => {
+    const res = await request(app).get('/facts/search?q=mold&limit=1&offset=0')
+    expect(res.status).toBe(200)
+    if (res.body.next !== null) {
+      expect(res.body.next).toContain('q=mold')
+      expect(res.body.next).toContain('/facts/search')
+    }
+  })
+})
+
+describe('next / prev links — GET /worst', () => {
+  it('without limit: next and prev are both null (full list returned)', async () => {
+    const res = await request(app).get('/worst')
+    expect(res.status).toBe(200)
+    expect(res.body.next).toBeNull()
+    expect(res.body.prev).toBeNull()
+  })
+
+  it('with limit: first page has next, no prev', async () => {
+    const res = await request(app).get('/worst?limit=3')
+    expect(res.status).toBe(200)
+    expect(typeof res.body.next).toBe('string')
+    expect(res.body.prev).toBeNull()
+    expect(res.body.next).toContain('limit=3')
+    expect(res.body.next).toContain('offset=3')
+  })
+
+  it('with limit and offset: middle page has both next and prev', async () => {
+    const res = await request(app).get('/worst?limit=3&offset=3')
+    expect(res.status).toBe(200)
+    expect(typeof res.body.next).toBe('string')
+    expect(typeof res.body.prev).toBe('string')
+  })
+
+  it('next link preserves tier filter', async () => {
+    const res = await request(app).get('/worst?limit=1&offset=0&tier=condemned')
+    expect(res.status).toBe(200)
+    if (res.body.next !== null) {
+      expect(res.body.next).toContain('tier=condemned')
+    }
+  })
+})


### PR DESCRIPTION
Closes #126

Depends on #125 (pagination base) — this branch is based on `issue-117-pagination`.

## What this adds

A `buildLinks()` function in `src/lib/paginate.ts` and `next`/`prev` URL strings in every paginated list response, so consumers can traverse pages without constructing URLs manually.

## Response shape (example: GET /facts/all?limit=5&offset=5)

```json
{
  "total": 55,
  "limit": 5,
  "offset": 5,
  "has_more": true,
  "next": "/facts/all?limit=5&offset=10",
  "prev": "/facts/all?limit=5&offset=0",
  "facts": [...]
}
```

## Link behaviour

| Situation | `next` | `prev` |
|---|---|---|
| First page (`offset=0`) | string if more items exist | `null` |
| Middle page | string | string |
| Last page | `null` | string |
| Out-of-range offset (e.g. `offset=9999`) | `null` | string |
| GET /worst with no `?limit` | `null` | `null` (full list returned) |

## Filters preserved in links

- `GET /facts/search`: `?q=` and `?category=` preserved
- `GET /timeline`: `?era=`, `?after=`, `?before=` preserved
- `GET /worst`: `?tier=` preserved
- `GET /severity/:tier`: tier baked into path

## Tests

+15 tests in `pagination.test.ts` covering: first/middle/last page link states, null when no limit set (GET /worst), null on out-of-range offset, filter param preservation in link URLs for search and timeline.