### PR TITLE
[cheese-hater] Add GET /cheese/leaderboard — most-hated cheese rankings

### DIFF
--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -53,6 +53,41 @@ export const ENDPOINTS = [
   },
   {
     method: 'GET',
+    path: '/cheese/leaderboard',
+    description: 'Top N most-hated cheeses ranked by score ascending (lower score = more hated). Supports ?limit=N (default 10, max 20). Each entry includes rank, score, severity tier, verdict, one-liner, and full roast.',
+    parameters: [
+      {
+        name: 'limit',
+        location: 'query',
+        type: 'integer',
+        required: false,
+        default: 10,
+        max: 20,
+        description: 'Number of cheeses to return. Capped at 20 — because after 20 entries you will need to lie down.',
+      },
+    ],
+    example_request: 'GET /cheese/leaderboard?limit=3',
+    example_response: {
+      description: 'The most-hated cheeses, ranked by score ascending. Lower score = more hated. There are no winners here.',
+      total_rated: 20,
+      showing: 3,
+      limit: 3,
+      entries: [
+        {
+          rank: 1,
+          cheese: 'Limburger',
+          score: 0.45,
+          severity_tier: 'catastrophic',
+          verdict: 'CATASTROPHIC',
+          one_liner: 'A cheese so pungent it has been banned from public transport.',
+          roast: 'Limburger is not a cheese. It is a biological event...',
+        },
+      ],
+      note: 'All information presented is damning. There is no exculpatory section.',
+    },
+  },
+  {
+    method: 'GET',
     path: '/cheese/:name',
     description: 'Unified full-profile endpoint. Returns every dimension of condemnation for any cheese in a single call: score, severity tier, structured verdict, smell, texture, cultural damage, co-condemned pairings, and a full roast. Unknown cheeses receive generic condemnation — never a 404.',
     parameters: [

--- a/src/routes/cheese.ts
+++ b/src/routes/cheese.ts
@@ -1,15 +1,24 @@
 /**
- * GET /cheese/:name — unified full-profile endpoint for any cheese.
+ * GET /cheese/leaderboard — top N most-hated cheeses ranked by score.
+ * GET /cheese/:name       — unified full-profile endpoint for any cheese.
  *
- * Aggregates every dimension of condemnation into a single response:
+ * /leaderboard: Returns all rated cheeses sorted by score ascending (lowest
+ * score = most hated). Supports ?limit=N (default 10, max 20). Each entry
+ * includes rank, score, severity tier, verdict, roast, and one-liner.
+ *
+ * /:name: Aggregates every dimension of condemnation into a single response:
  * score, severity tier, structured verdict, smell, texture, cultural damage,
  * pairings (co-condemned companions), and the full roast.
  *
  * Unknown cheeses receive generic condemnation data — never a 404.
  * All information presented is damning. There is no exculpatory section.
+ *
+ * ROUTING ORDER: /leaderboard must be registered before /:name so the static
+ * segment takes priority over the dynamic parameter match.
  */
 import { Router, Request, Response } from 'express'
 import { rateCheese, ratings } from '../lib/cheeseHater.js'
+import ratingsData from '../data/cheese-ratings.json' with { type: 'json' }
 import { VERDICT_TO_TIER, WHY_IT_WINS, defaultWhyItWins } from '../lib/worstAnnotations.js'
 import verdictsData from '../data/cheese-verdicts.json' with { type: 'json' }
 
@@ -44,7 +53,29 @@ interface Pairing {
   note: string
 }
 
+interface RatingsFile {
+  cheeses: {
+    name: string
+    shareable_card: { one_liner: string }
+  }[]
+}
+
+interface LeaderboardEntry {
+  rank: number
+  cheese: string
+  score: number
+  severity_tier: string
+  verdict: string
+  one_liner: string
+  roast: string
+}
+
 // ── Data ──────────────────────────────────────────────────────────────────────
+
+const ratingsFile = ratingsData as RatingsFile
+const oneLinerMap: Record<string, string> = Object.fromEntries(
+  ratingsFile.cheeses.map(c => [c.name.toLowerCase(), c.shareable_card.one_liner])
+)
 
 const data = verdictsData as VerdictsData
 const knownVerdicts = data.verdicts
@@ -103,7 +134,49 @@ function buildPairings(targetName: string, targetScore: number): Pairing[] {
     }))
 }
 
-// ── Route ─────────────────────────────────────────────────────────────────────
+// ── Routes ────────────────────────────────────────────────────────────────────
+
+// GET /cheese/leaderboard — top N most-hated cheeses by score (ascending = most hated first)
+router.get('/leaderboard', (req: Request, res: Response) => {
+  const DEFAULT_LIMIT = 10
+  const MAX_LIMIT = 20
+
+  const rawLimit = req.query.limit
+  let limit = DEFAULT_LIMIT
+  if (rawLimit !== undefined) {
+    const parsed = parseInt(String(rawLimit), 10)
+    if (isNaN(parsed) || parsed < 1) {
+      res.status(400).json({
+        error: 'Invalid ?limit value.',
+        hint: `Must be a positive integer between 1 and ${MAX_LIMIT}.`,
+      })
+      return
+    }
+    limit = Math.min(parsed, MAX_LIMIT)
+  }
+
+  const sorted = [...ratings].sort((a, b) => a.score - b.score)
+  const top = sorted.slice(0, limit)
+
+  const entries: LeaderboardEntry[] = top.map((r, i) => ({
+    rank: i + 1,
+    cheese: r.name,
+    score: r.score,
+    severity_tier: toSeverityTier(r.verdict),
+    verdict: r.verdict,
+    one_liner: oneLinerMap[r.name.toLowerCase()] ?? `${r.name}: condemned without qualification.`,
+    roast: buildRoastForCheese(r.name),
+  }))
+
+  res.json({
+    description: 'The most-hated cheeses, ranked by score ascending. Lower score = more hated. There are no winners here.',
+    total_rated: ratings.length,
+    showing: entries.length,
+    limit,
+    entries,
+    note: 'All information presented is damning. There is no exculpatory section.',
+  })
+})
 
 // GET /cheese/:name — unified full condemnation profile
 router.get('/:name', (req: Request, res: Response) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -75,6 +75,7 @@ app.get('/', (req, res) => {
       'GET /severity/:tier':    'Browse all cheeses at a given threat level (catastrophic / revolting / condemned)',
       'GET /severity/:tier/worst':     'The single most-condemned cheese in a tier',
       'GET /severity/:tier/least-bad': 'The single least-condemned cheese in a tier ("least bad" is not a compliment)',
+      'GET /cheese/leaderboard': 'Top N most-hated cheeses ranked by score ascending (lower = worse). Supports ?limit=N (default 10, max 20)',
       'GET /cheese/:name':       'Full unified condemnation profile — score, severity, verdict, smell, texture, cultural damage, pairings, and roast in a single call',
       'GET /roast':             'Get today\'s daily cheese roast — a different cheese condemned each day',
       'GET /roast/history':     'Browse past N days of roasted cheeses (default 7, max 30)',
@@ -127,6 +128,7 @@ app.use('/timeline', timelineRouter)
 // GET /severity/:tier — browse cheeses by threat level (catastrophic / revolting / condemned)
 app.use('/severity', severityRouter)
 
+// GET /cheese/leaderboard — top N most-hated cheeses
 // GET /cheese/:name — unified full-profile condemnation dossier
 app.use('/cheese', cheeseRouter)
 
@@ -143,6 +145,7 @@ app.use((_req, res) => {
       'GET /random-rant',
       'GET /counter',
       'GET /counter/:argument',
+      'GET /cheese/leaderboard',
       'GET /cheese/:name',
       'GET /rate',
       'GET /rate/:cheese',

--- a/src/tests/cheeseLeaderboard.test.ts
+++ b/src/tests/cheeseLeaderboard.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for GET /cheese/leaderboard — top N most-hated cheeses by score.
+ *
+ * Lower score = more hated. The leaderboard makes the hierarchy of suffering
+ * visible and browsable. All entries are damning. There are no positive results.
+ */
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import app from '../server'
+
+const REQUIRED_TOP_LEVEL_FIELDS = [
+  'description',
+  'total_rated',
+  'showing',
+  'limit',
+  'entries',
+  'note',
+] as const
+
+const REQUIRED_ENTRY_FIELDS = [
+  'rank',
+  'cheese',
+  'score',
+  'severity_tier',
+  'verdict',
+  'one_liner',
+  'roast',
+] as const
+
+describe('GET /cheese/leaderboard', () => {
+  it('returns 200 with correct top-level shape', async () => {
+    const res = await request(app).get('/cheese/leaderboard')
+    expect(res.status).toBe(200)
+    for (const field of REQUIRED_TOP_LEVEL_FIELDS) {
+      expect(res.body).toHaveProperty(field)
+    }
+  })
+
+  it('returns entries array with correct entry shape', async () => {
+    const res = await request(app).get('/cheese/leaderboard')
+    expect(res.status).toBe(200)
+    expect(Array.isArray(res.body.entries)).toBe(true)
+    expect(res.body.entries.length).toBeGreaterThan(0)
+    for (const entry of res.body.entries) {
+      for (const field of REQUIRED_ENTRY_FIELDS) {
+        expect(entry).toHaveProperty(field)
+      }
+    }
+  })
+
+  it('defaults to 10 entries', async () => {
+    const res = await request(app).get('/cheese/leaderboard')
+    expect(res.status).toBe(200)
+    expect(res.body.entries.length).toBe(10)
+    expect(res.body.limit).toBe(10)
+    expect(res.body.showing).toBe(10)
+  })
+
+  it('respects ?limit=N', async () => {
+    const res = await request(app).get('/cheese/leaderboard?limit=5')
+    expect(res.status).toBe(200)
+    expect(res.body.entries.length).toBe(5)
+    expect(res.body.limit).toBe(5)
+    expect(res.body.showing).toBe(5)
+  })
+
+  it('respects ?limit=1 — the single most-hated cheese', async () => {
+    const res = await request(app).get('/cheese/leaderboard?limit=1')
+    expect(res.status).toBe(200)
+    expect(res.body.entries.length).toBe(1)
+    expect(res.body.entries[0].rank).toBe(1)
+  })
+
+  it('caps limit at 20', async () => {
+    const res = await request(app).get('/cheese/leaderboard?limit=999')
+    expect(res.status).toBe(200)
+    expect(res.body.limit).toBe(20)
+    expect(res.body.entries.length).toBeLessThanOrEqual(20)
+  })
+
+  it('entries are sorted by score ascending (lower = more hated)', async () => {
+    const res = await request(app).get('/cheese/leaderboard?limit=20')
+    expect(res.status).toBe(200)
+    const scores: number[] = res.body.entries.map((e: { score: number }) => e.score)
+    for (let i = 1; i < scores.length; i++) {
+      expect(scores[i]).toBeGreaterThanOrEqual(scores[i - 1])
+    }
+  })
+
+  it('ranks are sequential starting from 1', async () => {
+    const res = await request(app).get('/cheese/leaderboard?limit=5')
+    expect(res.status).toBe(200)
+    const ranks: number[] = res.body.entries.map((e: { rank: number }) => e.rank)
+    expect(ranks).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it('each entry has a non-empty roast string', async () => {
+    const res = await request(app).get('/cheese/leaderboard?limit=5')
+    expect(res.status).toBe(200)
+    for (const entry of res.body.entries) {
+      expect(typeof entry.roast).toBe('string')
+      expect(entry.roast.length).toBeGreaterThan(10)
+    }
+  })
+
+  it('each entry has a non-empty one_liner', async () => {
+    const res = await request(app).get('/cheese/leaderboard?limit=5')
+    expect(res.status).toBe(200)
+    for (const entry of res.body.entries) {
+      expect(typeof entry.one_liner).toBe('string')
+      expect(entry.one_liner.length).toBeGreaterThan(5)
+    }
+  })
+
+  it('severity_tier is a non-empty lowercase string', async () => {
+    const res = await request(app).get('/cheese/leaderboard?limit=5')
+    expect(res.status).toBe(200)
+    for (const entry of res.body.entries) {
+      expect(typeof entry.severity_tier).toBe('string')
+      expect(entry.severity_tier).toBe(entry.severity_tier.toLowerCase())
+      expect(entry.severity_tier.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('total_rated reflects the full dataset size', async () => {
+    const res = await request(app).get('/cheese/leaderboard')
+    expect(res.status).toBe(200)
+    expect(typeof res.body.total_rated).toBe('number')
+    expect(res.body.total_rated).toBeGreaterThan(0)
+  })
+
+  it('note field is present and damning', async () => {
+    const res = await request(app).get('/cheese/leaderboard')
+    expect(res.status).toBe(200)
+    expect(typeof res.body.note).toBe('string')
+    expect(res.body.note.length).toBeGreaterThan(10)
+  })
+
+  it('returns 400 for ?limit=0', async () => {
+    const res = await request(app).get('/cheese/leaderboard?limit=0')
+    expect(res.status).toBe(400)
+    expect(res.body).toHaveProperty('error')
+    expect(res.body).toHaveProperty('hint')
+  })
+
+  it('returns 400 for ?limit=-1', async () => {
+    const res = await request(app).get('/cheese/leaderboard?limit=-1')
+    expect(res.status).toBe(400)
+    expect(res.body).toHaveProperty('error')
+  })
+
+  it('returns 400 for ?limit=abc', async () => {
+    const res = await request(app).get('/cheese/leaderboard?limit=abc')
+    expect(res.status).toBe(400)
+    expect(res.body).toHaveProperty('error')
+  })
+
+  it('does not conflict with GET /cheese/:name — leaderboard route takes priority', async () => {
+    // If routing were wrong, "leaderboard" would be treated as a cheese name
+    const leaderboard = await request(app).get('/cheese/leaderboard')
+    expect(leaderboard.status).toBe(200)
+    expect(leaderboard.body).toHaveProperty('entries')
+    expect(leaderboard.body).not.toHaveProperty('worst_quality') // profile shape absent
+  })
+
+  it('GET /cheese/brie still works after leaderboard route added', async () => {
+    const res = await request(app).get('/cheese/brie')
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveProperty('cheese')
+    expect(res.body).toHaveProperty('worst_quality')
+    expect(res.body).toHaveProperty('pairings')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `GET /cheese/leaderboard` endpoint returning the top N most-hated cheeses ranked by score ascending (lower = more condemned)
- Each entry includes: `rank`, `cheese`, `score`, `severity_tier`, `verdict`, `one_liner`, and full `roast`
- Supports `?limit=N` (default 10, max 20) with `400` validation for invalid values
- `/leaderboard` is registered **before** `/:name` in the router — static segment takes priority over the dynamic param so "leaderboard" is never mistaken for a cheese name
- Updates `api.ts` endpoint discovery schema and `server.ts` manifesto + 404 listing

## Test plan

- [x] 18 new tests covering: shape, default limit, custom limit, limit cap, sort order, sequential ranks, roast content, one-liner content, severity tier format, 400 on invalid limit, routing priority, and `/cheese/:name` still works
- [x] 691/691 total tests passing (`npx vitest run`)
- [x] Commit `081a2fe` on `origin/issue-137-cheese-leaderboard`

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)