### PR TITLE
[cheese-hater] Add GET /glossary — cheese terminology guide where every definition is also an indictment

### DIFF
--- a/src/data/cheese-glossary.json
+++ b/src/data/cheese-glossary.json
@@ -1,0 +1,212 @@
+{
+  "terms": [
+    {
+      "term": "affinage",
+      "pronunciation": "ah-fee-NAHJ",
+      "origin_language": "French",
+      "literal_meaning": "The art and process of maturing and refining cheese",
+      "what_it_actually_means": "Aging cheese in a controlled environment — a cave, a cellar, or a climate-controlled room — while monitoring it for weeks or months as bacteria and mold transform its flavor and texture. The word 'art' is doing significant work here. The actual activity is watching cheese change in a cold room.",
+      "used_in_a_sentence": "'The affinage on this Comté took 18 months.' Translation: someone spent 18 months in a cold room with cheese. They have been given a French title for this.",
+      "verdict": "A French word for 'we left it in a cave and watched it change' that has been elevated into a profession.",
+      "does_this_help": false,
+      "why_not": "Knowing the correct terminology for cheese aging does not make the aged cheese better. It makes you more articulate about why it is bad."
+    },
+    {
+      "term": "umami",
+      "pronunciation": "oo-MAH-mee",
+      "origin_language": "Japanese",
+      "literal_meaning": "The fifth basic taste — savoury, deeply satisfying, often described as 'pleasant savoury taste'",
+      "what_it_actually_means": "In the context of cheese, umami is the taste people point to when defending parmesan. The actual compounds responsible for this taste in parmesan include glutamic acid and butyric acid. Butyric acid is the same compound found in vomit. Umami is real; the idea that it excuses cheese is not.",
+      "used_in_a_sentence": "'Parmesan's umami makes it indispensable.' Translation: a taste compound found in several foods is also detectable in this particular fermented dairy product that smells like a gym locker.",
+      "verdict": "A legitimate taste concept co-opted by cheese advocates to make 'this smells like vomit' sound like a compliment.",
+      "does_this_help": false,
+      "why_not": "Understanding umami does not rehabilitate the cheese that deploys it. The vomit-smell compound is still there."
+    },
+    {
+      "term": "terroir",
+      "pronunciation": "teh-RWAHR",
+      "origin_language": "French",
+      "literal_meaning": "The complete natural environment in which a food is produced — soil, climate, topography — that gives it a distinctive character",
+      "what_it_actually_means": "In cheese, terroir means the flavor of the cheese reflects where and how the animals lived. Grass-fed in Alpine meadows, grazed on coastal salt flats, etc. This is presented as a reason to care about the cheese. The alternate interpretation: the cheese tastes different depending on what the cow ate. This remains, at its core, information about dairy.",
+      "used_in_a_sentence": "'You can taste the Alpine terroir in this Gruyère.' Translation: the cow ate different grass. The cheese still smells the same.",
+      "verdict": "A French wine concept retrofitted onto cheese to suggest that geography excuses fermented dairy. It does not.",
+      "does_this_help": false,
+      "why_not": "The terroir of the cow's pasture does not change the fact that the end product is curdled milk left to age until bacteria transform it."
+    },
+    {
+      "term": "cave-aged",
+      "pronunciation": "KAYV-ayjd",
+      "origin_language": "English",
+      "literal_meaning": "Cheese that has been aged in a natural or man-made cave, where temperature and humidity are naturally regulated",
+      "what_it_actually_means": "The cheese was stored underground. This is presented as a premium distinction — something to seek out, to pay more for. The cave regulates temperature and humidity, which is good for aging cheese. It is not, however, a quality endorsement for the result. The cave-aging process produces cheese. Cave-aged cheese is still cheese.",
+      "used_in_a_sentence": "'This cave-aged cheddar is exceptional.' Translation: this cheese was stored in a hole in the ground. It is still cheddar.",
+      "verdict": "A geographic descriptor that sounds artisanal but simply means 'stored underground.' The cave adds nothing except controlled humidity and a good story.",
+      "does_this_help": false,
+      "why_not": "The cave is a storage method. The cave does not transform cheese into something other than cheese."
+    },
+    {
+      "term": "rind",
+      "pronunciation": "RYND",
+      "origin_language": "Old English (hrind — bark, crust)",
+      "literal_meaning": "The outer layer or crust of a cheese, formed during aging",
+      "what_it_actually_means": "Depending on the type of cheese, the rind is formed by mold (bloomy rinds on Brie and Camembert), bacteria (washed rinds), salt, or simply drying. On soft cheeses, the rind is literally a layer of Penicillium mold that has been allowed to grow on the surface. The rind is technically edible. This fact is used to argue that you should eat mold. You are not obligated to eat mold simply because it is technically edible.",
+      "used_in_a_sentence": "'The rind is the best part.' This is said unironically by people who have decided to eat the mold.",
+      "verdict": "The outer layer of cheese, often composed of mold, bacteria, or both. Technically edible. Whether it should be eaten is a separate question.",
+      "does_this_help": false,
+      "why_not": "Knowing what a rind is does not make eating mold more appealing. It makes the nature of the thing you are being asked to eat more explicit."
+    },
+    {
+      "term": "curd",
+      "pronunciation": "KURD",
+      "origin_language": "Middle English",
+      "literal_meaning": "The thick, solidified protein that separates from milk when it is curdled",
+      "what_it_actually_means": "When milk is acidified (by bacteria or acid addition) or treated with rennet, the proteins coagulate into a solid mass. This solid mass is the curd. Cheese is made from curd. Curd is what happens to milk when it is deliberately broken. The whey drains off. What remains is pressed, salted, and aged into cheese. Understanding this process is not a defence of cheese. It is a description of how milk is systematically transformed into something else.",
+      "used_in_a_sentence": "'The curds are cut to control moisture content.' This is the moment where the milk has been broken into pieces and the dairy destruction is underway.",
+      "verdict": "The solid protein that results from curdling milk. The fundamental building block of all cheese. Knowing what it is does not make the result better.",
+      "does_this_help": false,
+      "why_not": "Curd is milk that has been made to break apart. The rest of the cheesemaking process is the treatment of this broken milk."
+    },
+    {
+      "term": "whey",
+      "pronunciation": "WAY",
+      "origin_language": "Old English (hwæg)",
+      "literal_meaning": "The liquid remaining after milk has been curdled and strained in the cheesemaking process",
+      "what_it_actually_means": "The liquid left over after the curd has been separated out. It contains water, lactose, proteins, and minerals. Whey is the byproduct of cheesemaking — what is left after the cheese part is extracted. Ricotta is made from whey. This means ricotta is a second product derived from what was already a byproduct of a process most people would prefer not to think about in detail.",
+      "used_in_a_sentence": "'Whey protein is highly bioavailable.' This is true. It is also a byproduct of cheese production. These facts coexist.",
+      "verdict": "The liquid remainder of the cheesemaking process. Ricotta is whey's most visible achievement, which should contextualise ricotta.",
+      "does_this_help": false,
+      "why_not": "Understanding whey's nutritional profile does not address the underlying situation, which is that it is the liquid left over from making cheese."
+    },
+    {
+      "term": "rennet",
+      "pronunciation": "REN-it",
+      "origin_language": "Middle English (from Old English gerun — to curdle)",
+      "literal_meaning": "A complex of enzymes used to coagulate milk in cheesemaking",
+      "what_it_actually_means": "Traditionally, rennet is extracted from the lining of the fourth stomach of ruminant animals (calves, lambs, goats). It contains enzymes — primarily chymosin — that cause milk proteins to coagulate. The cheese industry now also uses microbial and fermentation-derived rennet, but the traditional version is literal stomach extract. This is the enzyme that starts the process of turning milk into cheese. The origins of this process are visceral and were discovered accidentally, likely when milk was stored in animal stomachs and curdled.",
+      "used_in_a_sentence": "'Traditional cheesemakers still use animal rennet for authentic flavor.' Translation: stomach-lining extract is preferred for authentic results.",
+      "verdict": "The enzyme, traditionally from animal stomach lining, that initiates the curdling of milk. The cheese starts here.",
+      "does_this_help": false,
+      "why_not": "Knowing the origin of rennet is not calming information."
+    },
+    {
+      "term": "pasteurisation",
+      "pronunciation": "pass-cher-eye-ZAY-shun",
+      "origin_language": "Modern English (from Louis Pasteur)",
+      "literal_meaning": "The process of heating a liquid to a specific temperature for a set period of time to kill pathogenic microorganisms",
+      "what_it_actually_means": "For cheese, pasteurisation means heating the milk before cheesemaking to kill potentially harmful bacteria. Raw-milk (unpasteurised) cheese is made without this step. Many artisan and traditional cheese advocates prefer raw-milk cheese for its more complex flavour. This preference is for cheese that has not been treated to kill the bacteria. The bacteria contribute to the flavour. The debate in cheese is between 'cheese made from treated milk' and 'cheese made from milk in which the bacteria have been left alive and active.' Both produce cheese.",
+      "used_in_a_sentence": "'Raw-milk cheese has a superior, more complex flavour.' Translation: cheese made from milk that still contains live bacteria tastes different from cheese made from treated milk. Both are cheese.",
+      "verdict": "The process that makes cheese marginally safer by killing bacteria. The debate about its merit in cheesemaking is a debate about whether to leave certain bacteria in.",
+      "does_this_help": false,
+      "why_not": "Whether the milk was pasteurised or not, the end result is still cheese."
+    },
+    {
+      "term": "culture",
+      "pronunciation": "KUL-cher",
+      "origin_language": "Latin (cultura — cultivation, tending)",
+      "literal_meaning": "In cheesemaking: the bacterial cultures (starter cultures) added to milk to acidify it and begin the fermentation process",
+      "what_it_actually_means": "Specific strains of bacteria — primarily lactic acid bacteria — are added to milk to acidify it. This is the beginning of the transformation from milk to cheese. The bacteria produce acid and, in some cases, flavour compounds. The word 'culture' is doing a great deal of work to make this sound civilised. In practice, you are introducing bacteria to milk on purpose and monitoring what they do to it.",
+      "used_in_a_sentence": "'This cheese uses a house culture developed over 30 years.' Translation: this cheese uses a specific bacterial strain that the cheesemaker has been cultivating for three decades.",
+      "verdict": "Bacteria. Deliberately added bacteria that acidify milk and contribute to the eventual character of the cheese.",
+      "does_this_help": false,
+      "why_not": "'Culture' is a word associated with civilisation and refinement. In this context, it refers to bacteria. Knowing this does not make the bacteria more sophisticated."
+    },
+    {
+      "term": "bloomy rind",
+      "pronunciation": "BLOOM-ee RYND",
+      "origin_language": "English",
+      "literal_meaning": "A soft, white, edible mold coating that forms the exterior of certain cheeses (Brie, Camembert)",
+      "what_it_actually_means": "The white exterior of Brie and Camembert is a layer of Penicillium camemberti mold that has been cultivated to grow on the cheese's surface during aging. 'Bloomy' refers to the mold 'blooming' — spreading and growing across the cheese. The mold releases enzymes that break down the proteins in the cheese, softening it from the outside in. This is why Brie becomes softer and runnier over time: the mold is digesting it. The mold is literally eating the cheese. You are then eating the cheese along with the mold that has been eating it.",
+      "used_in_a_sentence": "'The bloomy rind on this Brie is perfect.' The mold has reached optimal development. It has been eating the cheese at the correct rate.",
+      "verdict": "Cultivated mold on the exterior of soft-ripened cheeses. The mold is not decorative — it is biologically active and digesting the cheese beneath it.",
+      "does_this_help": false,
+      "why_not": "Knowing that the white coating is mold eating the cheese from the outside does not make the cheese more appealing. It makes it more accurately described."
+    },
+    {
+      "term": "washed rind",
+      "pronunciation": "WOSHT RYND",
+      "origin_language": "English",
+      "literal_meaning": "Cheese whose exterior has been repeatedly washed with brine, beer, wine, or spirits during aging, producing a pungent, sticky, orange-brown rind",
+      "what_it_actually_means": "During aging, the cheese is regularly bathed in a liquid — often brine, beer, wine, or brandy — that encourages the growth of Brevibacterium linens, a bacteria responsible for the characteristic orange colour and extremely pungent smell of washed-rind cheeses. Limburger, Taleggio, Époisses, and Munster are washed-rind cheeses. The washing process is repeated throughout aging, feeding the bacteria and intensifying the smell. Brevibacterium linens is also found on human skin, where it contributes to body odour. The cheese smells like feet because it shares bacteria with feet. This is not a coincidence.",
+      "used_in_a_sentence": "'Washed-rind cheeses have a robust, pungent flavour that rewards the adventurous eater.' Translation: these cheeses smell extremely bad and taste accordingly. The smell is caused by the same bacteria responsible for foot odour.",
+      "verdict": "Cheese washed in liquid to cultivate bacteria that produce an orange rind and a smell measurably similar to body odour. The washing is done repeatedly, by choice.",
+      "does_this_help": false,
+      "why_not": "The information that washed-rind cheese smells like feet because it grows the same bacteria as feet is not helpful information. It is accurate information."
+    },
+    {
+      "term": "farmstead",
+      "pronunciation": "FARM-sted",
+      "origin_language": "English",
+      "literal_meaning": "Cheese produced on the same farm where the milk-producing animals are raised",
+      "what_it_actually_means": "Farmstead cheese means the entire process — animal husbandry, milking, and cheesemaking — happens in one location. This is presented as superior to large-scale production: more authentic, more connected to the land, more artisanal. The cheese is still the same substance regardless of whether it was made at a small farm or a large facility. The farm does not change what cheese is. It changes the scale and sometimes the flavour profile. The marketing category 'farmstead' is asking you to pay more for cheese because it was made near where the cow lived.",
+      "used_in_a_sentence": "'This farmstead cheddar comes from a single herd in Vermont.' Translation: this cheese was made close to where the cow was. It is still cheddar.",
+      "verdict": "A marketing designation indicating small-scale production. The cheese is still cheese. The farm is close. This is the entire distinction.",
+      "does_this_help": false,
+      "why_not": "The proximity of the cow to the cheesemaker does not change the nature of the product."
+    },
+    {
+      "term": "pdo",
+      "pronunciation": "PEE-dee-OH",
+      "origin_language": "English abbreviation (Protected Designation of Origin)",
+      "literal_meaning": "A European Union certification that a product must be produced, processed, and prepared within a specific geographical region, using established methods",
+      "what_it_actually_means": "PDO status means a cheese can only be called by its name if it comes from a specific place and is made in a specific way. Parmigiano-Reggiano can only be called that if it comes from specific provinces of northern Italy and follows strict production rules. Roquefort must come from caves near Roquefort-sur-Soulzon. The legal framework ensures authenticity. It is an extremely elaborate regulatory structure for protecting the names of cheeses. The cheeses are still cheese. They simply have legal protection for their names.",
+      "used_in_a_sentence": "'This is authentic PDO Camembert de Normandie.' Translation: this Camembert has met European regulatory requirements and was produced in a specific part of France. It is still Camembert.",
+      "verdict": "EU legal protection for cheese names. An entire regulatory apparatus exists to ensure the correct origin of cheese. The cheese is still cheese.",
+      "does_this_help": false,
+      "why_not": "The legal authenticity of the cheese's geographic origin does not affect what cheese is or why it should be approached with caution."
+    },
+    {
+      "term": "fondue",
+      "pronunciation": "fon-DYOO",
+      "origin_language": "French (from fondre — to melt)",
+      "literal_meaning": "A dish in which cheese (or chocolate) is melted in a communal pot and food is dipped into it",
+      "what_it_actually_means": "Fondue is Gruyère's highest-profile crime. A wheel of cheese — typically Gruyère, Emmental, or a combination — is melted with wine and garlic in a communal pot. People gather around this pot with long forks and dip bread into the molten cheese. The Swiss cheese industry significantly promoted fondue in the 1930s and 1960s to increase cheese consumption. The communal ritual was largely a marketing invention. A group of people has agreed to gather around a heat source and dip bread into melted dairy together. This is called an experience.",
+      "used_in_a_sentence": "'Fondue is the perfect winter sharing dish.' Translation: melted cheese is presented communally and everyone is expected to participate.",
+      "verdict": "Communal melted cheese. An activity in which multiple people share a single pot of liquefied dairy. The Swiss cheese industry created the modern ritual to sell more cheese.",
+      "does_this_help": false,
+      "why_not": "Knowing that fondue is largely a 20th-century marketing invention does not make the melted cheese easier to encounter."
+    },
+    {
+      "term": "mouthfeel",
+      "pronunciation": "MOUTH-feel",
+      "origin_language": "English",
+      "literal_meaning": "The physical sensations produced in the mouth by a food or drink, including texture, weight, and coating",
+      "what_it_actually_means": "In cheese contexts, mouthfeel describes whether a cheese is creamy, waxy, crumbly, grainy, gummy, or otherwise textured. It is a wine and food science term applied to cheese to make textural descriptions sound analytical. When someone describes the 'mouthfeel' of Brie as 'luxurious and coating,' they mean it feels soft and leaves a dairy film. When someone describes cottage cheese's mouthfeel as 'clean and refreshing,' they are working very hard.",
+      "used_in_a_sentence": "'The mouthfeel of this aged Gouda is remarkably smooth.' Translation: this cheese does not feel unpleasant in your mouth in the specific way other cheeses do.",
+      "verdict": "The textural experience of cheese in the mouth, described analytically to make the sensation of eating fermented dairy sound like a precision observation.",
+      "does_this_help": false,
+      "why_not": "Knowing the correct terminology for how cheese feels in your mouth does not change how cheese feels in your mouth."
+    },
+    {
+      "term": "lactic",
+      "pronunciation": "LAK-tik",
+      "origin_language": "Latin (lac — milk)",
+      "literal_meaning": "Relating to or producing lactic acid; in cheese, describes a clean, milky, slightly tart flavour from lactic acid bacteria fermentation",
+      "what_it_actually_means": "A 'lactic' cheese is one where the flavour is dominated by lactic acid — the compound produced by the bacteria that ferment the milk. Fresh, young cheeses like chèvre or fresh mozzarella are often described as lactic. The lactic acid is what gives yoghurt its tang. It is the acid produced when bacteria consume the lactose in milk. Describing a cheese as 'clean and lactic' means: this cheese tastes most clearly of the acid produced by its bacteria.",
+      "used_in_a_sentence": "'This fresh chèvre has a clean, lactic tang.' Translation: the bacteria have done their work and the resulting acid is the dominant flavour.",
+      "verdict": "A flavour descriptor for cheeses where bacterial acid production is the primary taste note. The bacteria are doing the most work.",
+      "does_this_help": false,
+      "why_not": "Describing bacterial acid production as 'clean and lactic' is technically accurate and not reassuring."
+    },
+    {
+      "term": "tyrosine crystals",
+      "pronunciation": "TY-roh-seen KRIS-tuls",
+      "origin_language": "Greek (tyros — cheese; originally named from cheese)",
+      "literal_meaning": "White, crunchy clusters of the amino acid tyrosine that form in aged cheeses as proteins break down",
+      "what_it_actually_means": "In hard, aged cheeses like Parmigiano-Reggiano, aged Gouda, or aged Cheddar, you sometimes encounter white, crunchy crystals. These are tyrosine, an amino acid that precipitates out as proteins degrade over long aging periods. Cheese connoisseurs consider these crystals a desirable sign of aging — evidence of proper development. The amino acid tyrosine literally has 'cheese' in its etymology: it was first isolated from cheese. The crystals are the products of protein breakdown over months or years of bacterial activity. They are crunchiness produced by long-term decay.",
+      "used_in_a_sentence": "'The tyrosine crystals in this 36-month Parmigiano are exquisite.' Translation: the protein has been breaking down for three years and has crystallised. The crunching is amino acid residue.",
+      "verdict": "Crunchy amino acid residue that forms as aged cheese proteins break down over time. Considered by enthusiasts to be a positive sign. The crystals are the products of protein degradation.",
+      "does_this_help": false,
+      "why_not": "The crunching in aged cheese is the texture of long-term protein breakdown. This information is now yours."
+    }
+  ],
+  "generic_term": {
+    "pronunciation": "varies",
+    "origin_language": "varies",
+    "literal_meaning": "A term from the world of cheese and dairy production",
+    "what_it_actually_means": "This term has not been specifically documented in the cheese-hater glossary. It is, however, from the world of cheese — a domain where most vocabulary exists to make the transformation of animal milk into fermented, bacteria-laden, mold-adjacent products sound sophisticated, artisanal, or desirable. The terminology of cheese is largely marketing dressed as expertise.",
+    "used_in_a_sentence": "The term was used in a sentence about cheese. This did not improve the cheese.",
+    "verdict": "An undocumented cheese term. Whatever it means, it describes something in the cheese world. This is sufficient for concern.",
+    "does_this_help": false,
+    "why_not": "Documenting every piece of cheese vocabulary would require more space than the cheese industry deserves. The undocumented terms carry the same general warning as the documented ones."
+  }
+}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -922,6 +922,55 @@ export const ENDPOINTS = [
       note: 'The least-bad cheese in the condemned tier. It is still condemned.',
     },
   },
+  {
+    method: 'GET',
+    path: '/glossary',
+    description: 'Returns all documented cheese terminology with pronunciation, literal meaning, and a verdict. Every term defined honestly — each definition strips the euphemism. does_this_help is always false.',
+    parameters: [],
+    example_request: 'GET /glossary',
+    example_response: {
+      description: 'The language of cheese, translated honestly. Every term defined, every definition a warning.',
+      terms: [
+        {
+          term: 'affinage',
+          pronunciation: 'ah-fee-NAHJ',
+          origin_language: 'French',
+          literal_meaning: 'The art and process of maturing and refining cheese',
+          verdict: "A French word for 'we left it in a cave and watched it change' that has been elevated into a profession.",
+          endpoint: '/glossary/affinage',
+        },
+      ],
+      total: 18,
+      does_this_help: false,
+      why_not: 'Knowing the vocabulary of cheese does not improve cheese. It improves your ability to describe why it is bad.',
+    },
+  },
+  {
+    method: 'GET',
+    path: '/glossary/:term',
+    description: 'Full definition for a single cheese term: pronunciation, origin language, literal meaning, what it actually means, used in a sentence, verdict, does_this_help (always false), and why_not. Unknown terms return a generic response — never a 404.',
+    parameters: [
+      {
+        name: 'term',
+        location: 'path',
+        type: 'string',
+        required: true,
+        description: "The cheese term to look up (e.g. 'affinage', 'rennet', 'umami'). Unknown terms return a generic condemnation. URL-encode multi-word terms.",
+      },
+    ],
+    example_request: 'GET /glossary/affinage',
+    example_response: {
+      term: 'affinage',
+      pronunciation: 'ah-fee-NAHJ',
+      origin_language: 'French',
+      literal_meaning: 'The art and process of maturing and refining cheese',
+      what_it_actually_means: "Aging cheese in a controlled environment while monitoring it for weeks or months as bacteria and mold transform its flavor and texture. The word 'art' is doing significant work here.",
+      used_in_a_sentence: "'The affinage on this Comté took 18 months.' Translation: someone spent 18 months in a cold room with cheese.",
+      verdict: "A French word for 'we left it in a cave and watched it change' that has been elevated into a profession.",
+      does_this_help: false,
+      why_not: 'Knowing the correct terminology for cheese aging does not make the aged cheese better.',
+    },
+  },
 ]
 
 router.get('/', (_req, res) => {

--- a/src/routes/glossary.ts
+++ b/src/routes/glossary.ts
@@ -1,0 +1,115 @@
+/**
+ * GET /glossary       — all cheese terminology, each definition an indictment.
+ * GET /glossary/:term — full detail for a single term.
+ *
+ * Every term in the cheese world exists to make fermented, bacteria-laden,
+ * mold-adjacent dairy sound sophisticated. This glossary strips the euphemism.
+ *
+ * Unknown terms return a generic response — never a 404.
+ * does_this_help is always false. Knowing the terminology does not
+ * rehabilitate the cheese.
+ */
+import { Router, Request, Response } from 'express'
+import glossaryData from '../data/cheese-glossary.json' with { type: 'json' }
+
+const router = Router()
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface GlossaryTerm {
+  term: string
+  pronunciation: string
+  origin_language: string
+  literal_meaning: string
+  what_it_actually_means: string
+  used_in_a_sentence: string
+  verdict: string
+  does_this_help: false
+  why_not: string
+}
+
+interface GlossaryData {
+  terms: GlossaryTerm[]
+  generic_term: Omit<GlossaryTerm, 'term'>
+}
+
+// ── Data ──────────────────────────────────────────────────────────────────────
+
+const { terms, generic_term } = glossaryData as GlossaryData
+
+// Build a lookup map: normalised term key → full entry
+const termMap: Record<string, GlossaryTerm> = Object.fromEntries(
+  terms.map(t => [t.term.toLowerCase(), t])
+)
+
+// Also index common multi-word aliases that users might search
+const ALIASES: Record<string, string> = {
+  'cave aged': 'cave-aged',
+  'bloomy': 'bloomy rind',
+  'washed': 'washed rind',
+  'pdo': 'pdo',
+  'protected designation of origin': 'pdo',
+  'tyrosine': 'tyrosine crystals',
+  'crystals': 'tyrosine crystals',
+  'pasteurization': 'pasteurisation',
+  'pasteurize': 'pasteurisation',
+}
+
+function findTerm(raw: string): GlossaryTerm | null {
+  const key = raw.toLowerCase().trim()
+
+  // Direct match
+  if (termMap[key]) return termMap[key]
+
+  // Alias match
+  const aliasTarget = ALIASES[key]
+  if (aliasTarget && termMap[aliasTarget]) return termMap[aliasTarget]
+
+  // Partial match — term starts with or contains the key
+  const partial = Object.values(termMap).find(
+    t => t.term.toLowerCase().startsWith(key) || key.startsWith(t.term.toLowerCase())
+  )
+  if (partial) return partial
+
+  return null
+}
+
+// ── Routes ────────────────────────────────────────────────────────────────────
+
+// GET /glossary — full term list (summary form)
+router.get('/', (_req: Request, res: Response) => {
+  res.json({
+    description: 'The language of cheese, translated honestly. Every term defined, every definition a warning.',
+    terms: terms.map(t => ({
+      term: t.term,
+      pronunciation: t.pronunciation,
+      origin_language: t.origin_language,
+      literal_meaning: t.literal_meaning,
+      verdict: t.verdict,
+      endpoint: `/glossary/${encodeURIComponent(t.term)}`,
+    })),
+    total: terms.length,
+    does_this_help: false,
+    why_not: 'Knowing the vocabulary of cheese does not improve cheese. It improves your ability to describe why it is bad.',
+  })
+})
+
+// GET /glossary/:term — full detail for a single term
+router.get('/:term', (req: Request, res: Response) => {
+  const raw = req.params.term.trim()
+  const entry = findTerm(raw)
+
+  if (entry) {
+    res.json(entry)
+    return
+  }
+
+  // Unknown term — generic fallback, never 404
+  res.json({
+    term: raw,
+    ...generic_term,
+    why_not: `The term "${raw}" has not been specifically documented here. ${generic_term.why_not}`,
+  })
+})
+
+export default router

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import searchRouter from './routes/search'
 import etymologyRouter from './routes/etymology'
 import timelineRouter from './routes/timeline'
 import severityRouter from './routes/severity'
+import glossaryRouter from './routes/glossary'
 import cheeseRouter from './routes/cheese'
 import { generateExplorerHtml } from './lib/explorerHtml'
 
@@ -75,6 +76,8 @@ app.get('/', (req, res) => {
       'GET /severity/:tier':    'Browse all cheeses at a given threat level (catastrophic / revolting / condemned)',
       'GET /severity/:tier/worst':     'The single most-condemned cheese in a tier',
       'GET /severity/:tier/least-bad': 'The single least-condemned cheese in a tier ("least bad" is not a compliment)',
+      'GET /glossary':          'All cheese terminology defined honestly — every term an indictment',
+      'GET /glossary/:term':    'Full definition for a single cheese term: pronunciation, what it actually means, verdict. does_this_help: false.',
       'GET /cheese/:name':       'Full unified condemnation profile — score, severity, verdict, smell, texture, cultural damage, pairings, and roast in a single call',
       'GET /roast':             'Get today\'s daily cheese roast — a different cheese condemned each day',
       'GET /roast/history':     'Browse past N days of roasted cheeses (default 7, max 30)',
@@ -127,6 +130,9 @@ app.use('/timeline', timelineRouter)
 // GET /severity/:tier — browse cheeses by threat level (catastrophic / revolting / condemned)
 app.use('/severity', severityRouter)
 
+// GET /glossary — cheese terminology, each definition an indictment
+app.use('/glossary', glossaryRouter)
+
 // GET /cheese/:name — unified full-profile condemnation dossier
 app.use('/cheese', cheeseRouter)
 
@@ -162,6 +168,8 @@ app.use((_req, res) => {
       'GET /severity/:tier',
       'GET /severity/:tier/worst',
       'GET /severity/:tier/least-bad',
+      'GET /glossary',
+      'GET /glossary/:term',
       'GET /roast',
       'GET /roast/history',
       'GET /roast/versus',

--- a/src/tests/glossary.test.ts
+++ b/src/tests/glossary.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests for GET /glossary and GET /glossary/:term.
+ *
+ * The language of cheese, translated honestly.
+ * Every term defined. Every definition a warning.
+ * does_this_help is always false.
+ */
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import app from '../server'
+
+const DOCUMENTED_TERMS = [
+  'affinage',
+  'umami',
+  'terroir',
+  'cave-aged',
+  'rind',
+  'curd',
+  'whey',
+  'rennet',
+  'pasteurisation',
+  'culture',
+  'bloomy rind',
+  'washed rind',
+  'farmstead',
+  'pdo',
+  'fondue',
+  'mouthfeel',
+  'lactic',
+  'tyrosine crystals',
+]
+
+const REQUIRED_LIST_TERM_FIELDS = [
+  'term',
+  'pronunciation',
+  'origin_language',
+  'literal_meaning',
+  'verdict',
+  'endpoint',
+] as const
+
+const REQUIRED_DETAIL_FIELDS = [
+  'term',
+  'pronunciation',
+  'origin_language',
+  'literal_meaning',
+  'what_it_actually_means',
+  'used_in_a_sentence',
+  'verdict',
+  'does_this_help',
+  'why_not',
+] as const
+
+// ── GET /glossary (list) ──────────────────────────────────────────────────────
+
+describe('GET /glossary', () => {
+  it('returns 200', async () => {
+    const res = await request(app).get('/glossary')
+    expect(res.status).toBe(200)
+  })
+
+  it('has a terms array', async () => {
+    const res = await request(app).get('/glossary')
+    expect(Array.isArray(res.body.terms)).toBe(true)
+    expect(res.body.terms.length).toBeGreaterThan(0)
+  })
+
+  it('has at least 15 terms', async () => {
+    const res = await request(app).get('/glossary')
+    expect(res.body.terms.length).toBeGreaterThanOrEqual(15)
+  })
+
+  it('total matches terms array length', async () => {
+    const res = await request(app).get('/glossary')
+    expect(res.body.total).toBe(res.body.terms.length)
+  })
+
+  it('does_this_help is false', async () => {
+    const res = await request(app).get('/glossary')
+    expect(res.body.does_this_help).toBe(false)
+  })
+
+  it('has a why_not field', async () => {
+    const res = await request(app).get('/glossary')
+    expect(typeof res.body.why_not).toBe('string')
+    expect(res.body.why_not.length).toBeGreaterThan(0)
+  })
+
+  it('each term entry has required fields', async () => {
+    const res = await request(app).get('/glossary')
+    for (const entry of res.body.terms) {
+      for (const field of REQUIRED_LIST_TERM_FIELDS) {
+        expect(entry).toHaveProperty(field)
+      }
+    }
+  })
+
+  it('each term endpoint matches /glossary/:term pattern', async () => {
+    const res = await request(app).get('/glossary')
+    for (const entry of res.body.terms) {
+      expect(entry.endpoint).toMatch(/^\/glossary\//)
+    }
+  })
+
+  it('all expected terms are present', async () => {
+    const res = await request(app).get('/glossary')
+    const names: string[] = res.body.terms.map((t: { term: string }) => t.term.toLowerCase())
+    const expectedLower = DOCUMENTED_TERMS.map(t => t.toLowerCase())
+    for (const expected of expectedLower) {
+      expect(names).toContain(expected)
+    }
+  })
+})
+
+// ── GET /glossary/:term (documented terms) ────────────────────────────────────
+
+describe('GET /glossary/:term — documented term (affinage)', () => {
+  it('returns 200', async () => {
+    const res = await request(app).get('/glossary/affinage')
+    expect(res.status).toBe(200)
+  })
+
+  it('returns all required detail fields', async () => {
+    const res = await request(app).get('/glossary/affinage')
+    for (const field of REQUIRED_DETAIL_FIELDS) {
+      expect(res.body).toHaveProperty(field)
+    }
+  })
+
+  it('term matches the requested term', async () => {
+    const res = await request(app).get('/glossary/affinage')
+    expect(res.body.term.toLowerCase()).toBe('affinage')
+  })
+
+  it('does_this_help is false', async () => {
+    const res = await request(app).get('/glossary/affinage')
+    expect(res.body.does_this_help).toBe(false)
+  })
+
+  it('verdict is a non-empty string', async () => {
+    const res = await request(app).get('/glossary/affinage')
+    expect(typeof res.body.verdict).toBe('string')
+    expect(res.body.verdict.length).toBeGreaterThan(5)
+  })
+
+  it('what_it_actually_means is longer than literal_meaning', async () => {
+    const res = await request(app).get('/glossary/affinage')
+    expect(res.body.what_it_actually_means.length).toBeGreaterThan(
+      res.body.literal_meaning.length
+    )
+  })
+})
+
+describe('GET /glossary/:term — rennet (the alarming one)', () => {
+  it('returns 200', async () => {
+    const res = await request(app).get('/glossary/rennet')
+    expect(res.status).toBe(200)
+  })
+
+  it('does_this_help is false', async () => {
+    const res = await request(app).get('/glossary/rennet')
+    expect(res.body.does_this_help).toBe(false)
+  })
+})
+
+describe('GET /glossary/:term — washed rind (URL encoded)', () => {
+  it('returns 200 for washed%20rind', async () => {
+    const res = await request(app).get('/glossary/washed%20rind')
+    expect(res.status).toBe(200)
+    expect(res.body.term.toLowerCase()).toBe('washed rind')
+  })
+
+  it('returns 200 for bloomy%20rind', async () => {
+    const res = await request(app).get('/glossary/bloomy%20rind')
+    expect(res.status).toBe(200)
+    expect(res.body.term.toLowerCase()).toBe('bloomy rind')
+  })
+})
+
+describe('GET /glossary/:term — pasteurisation / pasteurization alias', () => {
+  it('returns 200 for pasteurisation', async () => {
+    const res = await request(app).get('/glossary/pasteurisation')
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 200 for pasteurization (American spelling)', async () => {
+    const res = await request(app).get('/glossary/pasteurization')
+    expect(res.status).toBe(200)
+    expect(res.body.does_this_help).toBe(false)
+  })
+})
+
+describe('GET /glossary/:term — PDO', () => {
+  it('returns 200 for pdo', async () => {
+    const res = await request(app).get('/glossary/pdo')
+    expect(res.status).toBe(200)
+  })
+
+  it('does_this_help is false', async () => {
+    const res = await request(app).get('/glossary/pdo')
+    expect(res.body.does_this_help).toBe(false)
+  })
+})
+
+// ── does_this_help is always false ────────────────────────────────────────────
+
+describe('does_this_help is always false', () => {
+  const sampleTerms = ['affinage', 'rennet', 'fondue', 'umami', 'terroir', 'rind', 'curd']
+
+  for (const term of sampleTerms) {
+    it(`does_this_help is false for ${term}`, async () => {
+      const res = await request(app).get(`/glossary/${term}`)
+      expect(res.body.does_this_help).toBe(false)
+    })
+  }
+
+  it('does_this_help is false for unknown term', async () => {
+    const res = await request(app).get('/glossary/totally-made-up-cheese-word')
+    expect(res.body.does_this_help).toBe(false)
+  })
+})
+
+// ── Unknown terms — generic fallback, never 404 ───────────────────────────────
+
+describe('GET /glossary/:term — unknown term returns generic fallback', () => {
+  it('returns 200 for an unknown term', async () => {
+    const res = await request(app).get('/glossary/flobscottle')
+    expect(res.status).toBe(200)
+  })
+
+  it('unknown term response has all required detail fields', async () => {
+    const res = await request(app).get('/glossary/flobscottle')
+    for (const field of REQUIRED_DETAIL_FIELDS) {
+      expect(res.body).toHaveProperty(field)
+    }
+  })
+
+  it('unknown term response has does_this_help: false', async () => {
+    const res = await request(app).get('/glossary/flobscottle')
+    expect(res.body.does_this_help).toBe(false)
+  })
+
+  it('unknown term name appears in response', async () => {
+    const res = await request(app).get('/glossary/mystery-dairy-word')
+    expect(res.body.term.toLowerCase()).toBe('mystery-dairy-word')
+  })
+
+  it('unknown term why_not references the term', async () => {
+    const res = await request(app).get('/glossary/flobscottle')
+    expect(res.body.why_not.toLowerCase()).toContain('flobscottle')
+  })
+})
+
+// ── GET /api schema coverage ──────────────────────────────────────────────────
+
+describe('GET /api — schema includes glossary endpoints', () => {
+  it('GET /api lists /glossary', async () => {
+    const res = await request(app).get('/api')
+    const paths: string[] = res.body.endpoints.map((e: { path: string }) => e.path)
+    expect(paths).toContain('/glossary')
+  })
+
+  it('GET /api lists /glossary/:term', async () => {
+    const res = await request(app).get('/api')
+    const paths: string[] = res.body.endpoints.map((e: { path: string }) => e.path)
+    expect(paths).toContain('/glossary/:term')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `GET /glossary` — all 18 cheese terms in summary form (pronunciation, literal meaning, verdict, endpoint link)
- Adds `GET /glossary/:term` — full honest definition per term: what it actually means, used in a sentence, verdict, `does_this_help: false`, `why_not`
- **18 terms documented:** affinage, umami, terroir, cave-aged, rind, curd, whey, rennet, pasteurisation, culture, bloomy rind, washed rind, farmstead, PDO, fondue, mouthfeel, lactic, tyrosine crystals
- Unknown terms return a generic fallback — never a 404
- Aliases handled: `pasteurization` → `pasteurisation`, partial matches for multi-word terms, `pdo` for "Protected Designation of Origin"
- Endpoints added to `GET /api` discovery schema and `server.ts` manifesto + 404 listing

## Test plan

- [x] 38 new tests: list shape, ≥15 terms, does_this_help always false, all expected terms present, detail shape, URL-encoded multi-word terms, alias matching (pasteurization), unknown term fallback, why_not references unknown term, API schema coverage
- [x] 711/711 total tests passing (`npx vitest run`)
- [x] Commit `8616bbe` on `origin/issue-102-glossary`

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)