### PR TITLE
[cheese-hater] Add GET /stats — aggregate condemnation statistics

### DIFF
--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -922,6 +922,49 @@ export const ENDPOINTS = [
       note: 'The least-bad cheese in the condemned tier. It is still condemned.',
     },
   },
+  {
+    method: 'GET',
+    path: '/stats',
+    description: 'Aggregate condemnation statistics across the full cheese dataset. Returns total cheeses condemned, tier breakdown with percentages, average score, score extremes, per-dimension averages (smell/texture/taste/cultural_damage), and a country-of-origin ranking. Every number here is damning. does_this_help is always false.',
+    parameters: [],
+    example_request: 'GET /stats',
+    example_response: {
+      total_cheeses_condemned: 21,
+      average_condemnation_score: 1.61,
+      score_range: {
+        lowest: 0.13,
+        lowest_cheese: 'Casu Martzu',
+        highest: 2.98,
+        highest_cheese: 'Gouda',
+        note: 'Higher scores indicate marginally less offensive cheese. No cheese has ever scored above 3.0. None will.',
+      },
+      tier_breakdown: [
+        { tier: 'revolting', count: 10, percentage: 47.62 },
+        { tier: 'condemned', count: 7, percentage: 33.33 },
+        { tier: 'catastrophic', count: 4, percentage: 19.05 },
+      ],
+      verdict_breakdown: [
+        { name: 'REVOLTING', count: 10, percentage: 47.62 },
+        { name: 'CONDEMNED', count: 7, percentage: 33.33 },
+        { name: 'CATASTROPHIC', count: 4, percentage: 19.05 },
+      ],
+      dimension_averages: {
+        smell: 1.58,
+        texture: 1.64,
+        taste: 1.71,
+        cultural_damage: 1.52,
+        most_offensive_dimension: 'taste',
+        note: 'All dimensions measured on a 0–10 scale where higher scores indicate more offensive cheese.',
+      },
+      most_condemned_origin: {
+        country: 'Italy',
+        cheese_count: 5,
+        note: 'Italy has contributed 5 cheeses to the condemned register. This is not a compliment.',
+      },
+      does_this_help: false,
+      why_not: 'Statistics do not rehabilitate cheese. They measure how bad it is across 21 confirmed cases.',
+    },
+  },
 ]
 
 router.get('/', (_req, res) => {

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -1,0 +1,172 @@
+/**
+ * GET /stats — aggregate condemnation statistics.
+ *
+ * The numbers behind the hatred. This endpoint surfaces the full shape of
+ * the cheese-hater's dataset: how many cheeses have been condemned, what
+ * percentage are catastrophic, which country of origin produces the most
+ * offense, and what the average score is (spoiler: bad).
+ *
+ * Every number here is damning. The statistics do not exculpate cheese.
+ * They quantify it.
+ */
+import { Router, Request, Response } from 'express'
+import { ratings } from '../lib/cheeseHater.js'
+import { VERDICT_TO_TIER } from '../lib/worstAnnotations.js'
+import ratingsData from '../data/cheese-ratings.json' with { type: 'json' }
+
+const router = Router()
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface RatingEntry {
+  name: string
+  origin: string
+  scores: {
+    smell: number
+    texture: number
+    taste: number
+    cultural_damage: number
+  }
+  aggregate: number
+  verdict: string
+}
+
+interface RatingsData {
+  cheeses: RatingEntry[]
+}
+
+// ── Data ──────────────────────────────────────────────────────────────────────
+
+const { cheeses } = ratingsData as RatingsData
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Count occurrences of each value in an array of strings. */
+function countBy(items: string[]): Record<string, number> {
+  return items.reduce<Record<string, number>>((acc, item) => {
+    acc[item] = (acc[item] ?? 0) + 1
+    return acc
+  }, {})
+}
+
+/** Sort a record by value descending and return as sorted array of {key, count}. */
+function rankEntries(counts: Record<string, number>): { name: string; count: number }[] {
+  return Object.entries(counts)
+    .sort((a, b) => b[1] - a[1])
+    .map(([name, count]) => ({ name, count }))
+}
+
+/** Round to two decimal places. */
+function r2(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+// ── Route ─────────────────────────────────────────────────────────────────────
+
+router.get('/', (_req: Request, res: Response) => {
+  const total = cheeses.length
+
+  // ── Tier breakdown ────────────────────────────────────────────────────────
+  const tierCounts = countBy(
+    ratings.map(r => VERDICT_TO_TIER[r.verdict] ?? r.verdict.toLowerCase())
+  )
+
+  const tierBreakdown = Object.entries(tierCounts).map(([tier, count]) => ({
+    tier,
+    count,
+    percentage: r2((count / total) * 100),
+    note: tierNote(tier),
+  }))
+
+  // ── Score statistics ──────────────────────────────────────────────────────
+  const scores = cheeses.map(c => c.aggregate)
+  const averageScore = r2(scores.reduce((a, b) => a + b, 0) / scores.length)
+  const lowestScore = r2(Math.min(...scores))
+  const highestScore = r2(Math.max(...scores))
+
+  const lowestCheese = cheeses.find(c => c.aggregate === Math.min(...scores))
+  const highestCheese = cheeses.find(c => c.aggregate === Math.max(...scores))
+
+  // ── Dimension averages ────────────────────────────────────────────────────
+  const avgSmell = r2(cheeses.reduce((a, c) => a + c.scores.smell, 0) / total)
+  const avgTexture = r2(cheeses.reduce((a, c) => a + c.scores.texture, 0) / total)
+  const avgTaste = r2(cheeses.reduce((a, c) => a + c.scores.taste, 0) / total)
+  const avgCulturalDamage = r2(cheeses.reduce((a, c) => a + c.scores.cultural_damage, 0) / total)
+
+  // Most offensive dimension (highest average = worst)
+  const dimensions: { name: string; average: number }[] = [
+    { name: 'smell', average: avgSmell },
+    { name: 'texture', average: avgTexture },
+    { name: 'taste', average: avgTaste },
+    { name: 'cultural_damage', average: avgCulturalDamage },
+  ]
+  const mostOffensiveDimension = [...dimensions].sort((a, b) => b.average - a.average)[0]
+
+  // ── Country of origin breakdown ───────────────────────────────────────────
+  // Normalise compound origins (e.g. "Sardinia, Italy" → "Italy")
+  const normalisedOrigins = cheeses.map(c => normaliseOrigin(c.origin))
+  const originCounts = countBy(normalisedOrigins)
+  const originRanking = rankEntries(originCounts)
+  const mostCondemnedOrigin = originRanking[0]
+
+  // ── Verdict breakdown ─────────────────────────────────────────────────────
+  const verdictCounts = countBy(cheeses.map(c => c.verdict))
+  const verdictBreakdown = rankEntries(verdictCounts).map(e => ({
+    ...e,
+    percentage: r2((e.count / total) * 100),
+  }))
+
+  res.json({
+    total_cheeses_condemned: total,
+    average_condemnation_score: averageScore,
+    score_range: {
+      lowest: lowestScore,
+      lowest_cheese: lowestCheese?.name ?? 'unknown',
+      highest: highestScore,
+      highest_cheese: highestCheese?.name ?? 'unknown',
+      note: 'Higher scores indicate marginally less offensive cheese. No cheese has ever scored above 3.0. None will.',
+    },
+    tier_breakdown: tierBreakdown,
+    verdict_breakdown: verdictBreakdown,
+    dimension_averages: {
+      smell: avgSmell,
+      texture: avgTexture,
+      taste: avgTaste,
+      cultural_damage: avgCulturalDamage,
+      most_offensive_dimension: mostOffensiveDimension.name,
+      note: 'All dimensions measured on a 0–10 scale where higher scores indicate more offensive cheese. Every average here is bad.',
+    },
+    origin_breakdown: originRanking,
+    most_condemned_origin: {
+      country: mostCondemnedOrigin.name,
+      cheese_count: mostCondemnedOrigin.count,
+      note: `${mostCondemnedOrigin.name} has contributed ${mostCondemnedOrigin.count} cheeses to the condemned register. This is not a compliment.`,
+    },
+    methodology: 'Each cheese is assessed across smell, texture, taste, and cultural damage (0–10 per dimension). The aggregate score is the mean. All cheeses score poorly. The scale exists only to rank degrees of failure.',
+    does_this_help: false,
+    why_not: 'Statistics do not rehabilitate cheese. They measure how bad it is across 21 confirmed cases. The data is consistent: cheese is consistently terrible.',
+  })
+})
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function tierNote(tier: string): string {
+  switch (tier) {
+    case 'catastrophic': return 'The apex of dairy failure. These cheeses represent the full deployment of everything wrong with fermented milk.'
+    case 'revolting':    return 'Serious and sustained dairy offenses. Not catastrophic only because the catastrophic tier exists.'
+    case 'condemned':    return 'The least bad tier of a bad thing is still a bad thing. Still cheese. Still guilty.'
+    default:             return 'Condemned by assessment. No further notes available.'
+  }
+}
+
+function normaliseOrigin(origin: string): string {
+  // Handle compound strings like "Sardinia, Italy" → "Italy"
+  if (origin.includes(', Italy')) return 'Italy'
+  if (origin.includes(', France')) return 'France'
+  // Handle compound origins like "Various (Roquefort, Stilton, Gorgonzola)" → "Various"
+  if (origin.startsWith('Various')) return 'Various'
+  // Handle "Belgium/Germany" → keep as-is for accuracy
+  return origin
+}
+
+export default router

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import etymologyRouter from './routes/etymology'
 import timelineRouter from './routes/timeline'
 import severityRouter from './routes/severity'
 import cheeseRouter from './routes/cheese'
+import statsRouter from './routes/stats'
 import { generateExplorerHtml } from './lib/explorerHtml'
 
 const app = express()
@@ -82,6 +83,7 @@ app.get('/', (req, res) => {
       'GET /roast/bracket':     'Run 4–8 cheeses through a single-elimination tournament of condemnation',
       'GET /roast/leaderboard': 'Top N most-condemned cheeses ranked by 30-day appearance count',
       'POST /roast/submit':     'Submit any cheese for immediate condemnation; appears in /roast/history',
+      'GET /stats':             'Aggregate condemnation statistics — totals, tier breakdown, average score, most-condemned origin, dimension averages',
       'GET /health':            'Confirm the agent is operational and hates cheese',
     },
     note: 'No cheese has ever scored above 1.5/10. No cheese ever will. Visit / in a browser to explore interactively.',
@@ -130,6 +132,9 @@ app.use('/severity', severityRouter)
 // GET /cheese/:name — unified full-profile condemnation dossier
 app.use('/cheese', cheeseRouter)
 
+// GET /stats — aggregate condemnation statistics across the full cheese dataset
+app.use('/stats', statsRouter)
+
 // GET /api — endpoint discovery: all routes, parameters, and example responses
 app.use('/api', apiRouter)
 
@@ -162,6 +167,7 @@ app.use((_req, res) => {
       'GET /severity/:tier',
       'GET /severity/:tier/worst',
       'GET /severity/:tier/least-bad',
+      'GET /stats',
       'GET /roast',
       'GET /roast/history',
       'GET /roast/versus',

--- a/src/tests/stats.test.ts
+++ b/src/tests/stats.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Tests for GET /stats — aggregate condemnation statistics.
+ *
+ * The numbers confirm what the hatred already knew: cheese is consistently
+ * and quantifiably terrible. does_this_help is always false.
+ */
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import app from '../server'
+
+// ── GET /stats ────────────────────────────────────────────────────────────────
+
+describe('GET /stats', () => {
+  it('returns 200', async () => {
+    const res = await request(app).get('/stats')
+    expect(res.status).toBe(200)
+  })
+
+  it('returns JSON', async () => {
+    const res = await request(app).get('/stats')
+    expect(res.headers['content-type']).toMatch(/json/)
+  })
+})
+
+// ── Top-level required fields ─────────────────────────────────────────────────
+
+describe('GET /stats — required top-level fields', () => {
+  const REQUIRED_FIELDS = [
+    'total_cheeses_condemned',
+    'average_condemnation_score',
+    'score_range',
+    'tier_breakdown',
+    'verdict_breakdown',
+    'dimension_averages',
+    'origin_breakdown',
+    'most_condemned_origin',
+    'methodology',
+    'does_this_help',
+    'why_not',
+  ] as const
+
+  for (const field of REQUIRED_FIELDS) {
+    it(`has required field: ${field}`, async () => {
+      const res = await request(app).get('/stats')
+      expect(res.body).toHaveProperty(field)
+    })
+  }
+
+  it('does_this_help is false', async () => {
+    const res = await request(app).get('/stats')
+    expect(res.body.does_this_help).toBe(false)
+  })
+
+  it('why_not is a non-empty string', async () => {
+    const res = await request(app).get('/stats')
+    expect(typeof res.body.why_not).toBe('string')
+    expect(res.body.why_not.length).toBeGreaterThan(10)
+  })
+})
+
+// ── total_cheeses_condemned ───────────────────────────────────────────────────
+
+describe('GET /stats — total_cheeses_condemned', () => {
+  it('is a positive integer', async () => {
+    const res = await request(app).get('/stats')
+    expect(typeof res.body.total_cheeses_condemned).toBe('number')
+    expect(res.body.total_cheeses_condemned).toBeGreaterThan(0)
+    expect(Number.isInteger(res.body.total_cheeses_condemned)).toBe(true)
+  })
+
+  it('is at least 20 (we have 21 rated cheeses)', async () => {
+    const res = await request(app).get('/stats')
+    expect(res.body.total_cheeses_condemned).toBeGreaterThanOrEqual(20)
+  })
+})
+
+// ── average_condemnation_score ────────────────────────────────────────────────
+
+describe('GET /stats — average_condemnation_score', () => {
+  it('is a number', async () => {
+    const res = await request(app).get('/stats')
+    expect(typeof res.body.average_condemnation_score).toBe('number')
+  })
+
+  it('is between 0 and 10', async () => {
+    const res = await request(app).get('/stats')
+    expect(res.body.average_condemnation_score).toBeGreaterThan(0)
+    expect(res.body.average_condemnation_score).toBeLessThan(10)
+  })
+
+  it('no cheese scores above 3.0 on average', async () => {
+    const res = await request(app).get('/stats')
+    expect(res.body.average_condemnation_score).toBeLessThan(3)
+  })
+})
+
+// ── score_range ───────────────────────────────────────────────────────────────
+
+describe('GET /stats — score_range', () => {
+  it('has lowest, lowest_cheese, highest, highest_cheese, note', async () => {
+    const res = await request(app).get('/stats')
+    const sr = res.body.score_range
+    expect(sr).toHaveProperty('lowest')
+    expect(sr).toHaveProperty('lowest_cheese')
+    expect(sr).toHaveProperty('highest')
+    expect(sr).toHaveProperty('highest_cheese')
+    expect(sr).toHaveProperty('note')
+  })
+
+  it('lowest < highest', async () => {
+    const res = await request(app).get('/stats')
+    expect(res.body.score_range.lowest).toBeLessThan(res.body.score_range.highest)
+  })
+
+  it('lowest_cheese is Casu Martzu', async () => {
+    const res = await request(app).get('/stats')
+    expect(res.body.score_range.lowest_cheese).toBe('Casu Martzu')
+  })
+
+  it('note is a non-empty string', async () => {
+    const res = await request(app).get('/stats')
+    expect(typeof res.body.score_range.note).toBe('string')
+    expect(res.body.score_range.note.length).toBeGreaterThan(5)
+  })
+})
+
+// ── tier_breakdown ────────────────────────────────────────────────────────────
+
+describe('GET /stats — tier_breakdown', () => {
+  it('is an array', async () => {
+    const res = await request(app).get('/stats')
+    expect(Array.isArray(res.body.tier_breakdown)).toBe(true)
+  })
+
+  it('has 3 tiers (catastrophic, revolting, condemned)', async () => {
+    const res = await request(app).get('/stats')
+    expect(res.body.tier_breakdown).toHaveLength(3)
+  })
+
+  it('each entry has tier, count, percentage, note', async () => {
+    const res = await request(app).get('/stats')
+    for (const entry of res.body.tier_breakdown) {
+      expect(entry).toHaveProperty('tier')
+      expect(entry).toHaveProperty('count')
+      expect(entry).toHaveProperty('percentage')
+      expect(entry).toHaveProperty('note')
+    }
+  })
+
+  it('tier counts sum to total_cheeses_condemned', async () => {
+    const res = await request(app).get('/stats')
+    const total = res.body.total_cheeses_condemned
+    const sum = res.body.tier_breakdown.reduce((acc: number, t: { count: number }) => acc + t.count, 0)
+    expect(sum).toBe(total)
+  })
+
+  it('percentages sum to ~100', async () => {
+    const res = await request(app).get('/stats')
+    const sum = res.body.tier_breakdown.reduce(
+      (acc: number, t: { percentage: number }) => acc + t.percentage,
+      0
+    )
+    expect(sum).toBeCloseTo(100, 0)
+  })
+
+  it('all three valid tier names present', async () => {
+    const res = await request(app).get('/stats')
+    const tierNames = res.body.tier_breakdown.map((t: { tier: string }) => t.tier)
+    expect(tierNames).toContain('catastrophic')
+    expect(tierNames).toContain('revolting')
+    expect(tierNames).toContain('condemned')
+  })
+})
+
+// ── verdict_breakdown ─────────────────────────────────────────────────────────
+
+describe('GET /stats — verdict_breakdown', () => {
+  it('is an array', async () => {
+    const res = await request(app).get('/stats')
+    expect(Array.isArray(res.body.verdict_breakdown)).toBe(true)
+  })
+
+  it('each entry has name, count, percentage', async () => {
+    const res = await request(app).get('/stats')
+    for (const entry of res.body.verdict_breakdown) {
+      expect(entry).toHaveProperty('name')
+      expect(entry).toHaveProperty('count')
+      expect(entry).toHaveProperty('percentage')
+    }
+  })
+
+  it('verdict counts sum to total', async () => {
+    const res = await request(app).get('/stats')
+    const total = res.body.total_cheeses_condemned
+    const sum = res.body.verdict_breakdown.reduce((acc: number, v: { count: number }) => acc + v.count, 0)
+    expect(sum).toBe(total)
+  })
+})
+
+// ── dimension_averages ────────────────────────────────────────────────────────
+
+describe('GET /stats — dimension_averages', () => {
+  const DIMENSION_FIELDS = ['smell', 'texture', 'taste', 'cultural_damage', 'most_offensive_dimension', 'note'] as const
+
+  for (const field of DIMENSION_FIELDS) {
+    it(`has field: ${field}`, async () => {
+      const res = await request(app).get('/stats')
+      expect(res.body.dimension_averages).toHaveProperty(field)
+    })
+  }
+
+  it('all numeric dimensions are between 0 and 10', async () => {
+    const res = await request(app).get('/stats')
+    const da = res.body.dimension_averages
+    for (const dim of ['smell', 'texture', 'taste', 'cultural_damage']) {
+      expect(da[dim]).toBeGreaterThan(0)
+      expect(da[dim]).toBeLessThanOrEqual(10)
+    }
+  })
+
+  it('most_offensive_dimension is one of the valid dimensions', async () => {
+    const res = await request(app).get('/stats')
+    const valid = ['smell', 'texture', 'taste', 'cultural_damage']
+    expect(valid).toContain(res.body.dimension_averages.most_offensive_dimension)
+  })
+})
+
+// ── origin_breakdown ──────────────────────────────────────────────────────────
+
+describe('GET /stats — origin_breakdown', () => {
+  it('is an array', async () => {
+    const res = await request(app).get('/stats')
+    expect(Array.isArray(res.body.origin_breakdown)).toBe(true)
+  })
+
+  it('is non-empty', async () => {
+    const res = await request(app).get('/stats')
+    expect(res.body.origin_breakdown.length).toBeGreaterThan(0)
+  })
+
+  it('each entry has name and count', async () => {
+    const res = await request(app).get('/stats')
+    for (const entry of res.body.origin_breakdown) {
+      expect(entry).toHaveProperty('name')
+      expect(entry).toHaveProperty('count')
+      expect(typeof entry.name).toBe('string')
+      expect(typeof entry.count).toBe('number')
+    }
+  })
+
+  it('origin counts sum to total_cheeses_condemned', async () => {
+    const res = await request(app).get('/stats')
+    const total = res.body.total_cheeses_condemned
+    const sum = res.body.origin_breakdown.reduce((acc: number, o: { count: number }) => acc + o.count, 0)
+    expect(sum).toBe(total)
+  })
+
+  it('is sorted descending by count', async () => {
+    const res = await request(app).get('/stats')
+    const counts = res.body.origin_breakdown.map((o: { count: number }) => o.count)
+    for (let i = 0; i < counts.length - 1; i++) {
+      expect(counts[i]).toBeGreaterThanOrEqual(counts[i + 1])
+    }
+  })
+})
+
+// ── most_condemned_origin ─────────────────────────────────────────────────────
+
+describe('GET /stats — most_condemned_origin', () => {
+  it('has country, cheese_count, note', async () => {
+    const res = await request(app).get('/stats')
+    const mco = res.body.most_condemned_origin
+    expect(mco).toHaveProperty('country')
+    expect(mco).toHaveProperty('cheese_count')
+    expect(mco).toHaveProperty('note')
+  })
+
+  it('cheese_count is positive', async () => {
+    const res = await request(app).get('/stats')
+    expect(res.body.most_condemned_origin.cheese_count).toBeGreaterThan(0)
+  })
+
+  it('note references the country name', async () => {
+    const res = await request(app).get('/stats')
+    const { country, note } = res.body.most_condemned_origin
+    expect(note).toContain(country)
+  })
+
+  it('most_condemned_origin matches first entry of origin_breakdown', async () => {
+    const res = await request(app).get('/stats')
+    const top = res.body.origin_breakdown[0]
+    expect(res.body.most_condemned_origin.country).toBe(top.name)
+    expect(res.body.most_condemned_origin.cheese_count).toBe(top.count)
+  })
+})
+
+// ── GET /api schema coverage ──────────────────────────────────────────────────
+
+describe('GET /api — schema includes /stats', () => {
+  it('GET /api lists /stats', async () => {
+    const res = await request(app).get('/api')
+    const paths: string[] = res.body.endpoints.map((e: { path: string }) => e.path)
+    expect(paths).toContain('/stats')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `GET /stats` endpoint returning aggregate condemnation statistics across the full 21-cheese dataset
- **total_cheeses_condemned**: count of all rated cheeses
- **average_condemnation_score**: mean aggregate score (currently 1.61 — bad)
- **score_range**: lowest/highest cheese with names and a note that no cheese has ever scored above 3.0
- **tier_breakdown**: count + percentage per tier (catastrophic/revolting/condemned), with notes
- **verdict_breakdown**: raw verdict counts (CATASTROPHIC/REVOLTING/CONDEMNED) with percentages
- **dimension_averages**: per-dimension means (smell, texture, taste, cultural_damage) + most offensive dimension
- **origin_breakdown**: countries of origin ranked by cheese count descending
- **most_condemned_origin**: top offending country with contextual note
- `does_this_help: false` — always

## Test plan

- [ ] `npm test` — 724/724 pass (51 new tests in `src/tests/stats.test.ts`)
- [ ] `GET /stats` returns 200 with all required fields
- [ ] tier counts + percentages sum to total and ~100%
- [ ] origin counts sum to total_cheeses_condemned
- [ ] `does_this_help` is always `false`
- [ ] `GET /api` lists `/stats` in the endpoint registry

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)